### PR TITLE
double vert notation

### DIFF
--- a/R/lmer.R
+++ b/R/lmer.R
@@ -12,7 +12,8 @@
 ##'    \code{~} operator and the terms, separated by \code{+} operators, on
 ##'    the right.  Random-effects terms are distinguished by vertical bars
 ##'    (\code{"|"}) separating expressions for design matrices from
-##'    grouping factors.
+##'    grouping factors. Two vertical bars (\code{||}) can be used to specify 
+##'    multiple uncorrelated random effects for the same grouping variable.
 ##' @param data an optional data frame containing the variables named in
 ##'    \code{formula}.  By default the variables are taken from the environment
 ##'    from which \code{lmer} is called. While \code{data} is optional,
@@ -94,9 +95,9 @@
 ##' }
 ##' @examples
 ##' ## linear mixed models - reference values from older code
-##' (fm1 <- lmer(Reaction ~ Days + (Days|Subject), sleepstudy))
+##' (fm1 <- lmer(Reaction ~ Days + (Days | Subject), sleepstudy))
 ##' fm1_ML <- update(fm1,REML=FALSE)
-##' (fm2 <- lmer(Reaction ~ Days + (1|Subject) + (0+Days|Subject), sleepstudy))
+##' (fm2 <- lmer(Reaction ~ Days + (Days || Subject), sleepstudy))
 ##' anova(fm1, fm2)
 ##' @export
 ##' @importFrom minqa bobyqa

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1,5 +1,5 @@
 if(getRversion() < "2.15")
-    paste0 <- function(...) paste(..., sep = '')
+  paste0 <- function(...) paste(..., sep = '')
 
 ### Utilities for parsing and manipulating mixed-model formulas
 
@@ -26,106 +26,106 @@ if(getRversion() < "2.15")
 ##' @family utilities
 ##' @export
 mkReTrms <- function(bars, fr) {
-    if (!length(bars))
-	stop("No random effects terms specified in formula")
-    stopifnot(is.list(bars), all(sapply(bars, is.language)),
-	      inherits(fr, "data.frame"))
-    names(bars) <- unlist(lapply(bars, function(x) deparse(x[[3]])))
-
-    ## auxiliary {named, for easier inspection}:
-    mkBlist <- function(x) {
-        frloc <- fr
-        ## convert grouping variables to factors as necessary
-        for (i in all.vars(x[[3]])) {
-            frloc[[i]] <- factor(frloc[[i]])
-        }
-	ff <- eval(substitute(factor(fac), list(fac = x[[3]])), frloc)
-	if (all(is.na(ff)))
-	    stop("Invalid grouping factor specification, ",
-		 deparse(x[[3]]))
-	nl <- length(levels(ff))
-	mm <- model.matrix(eval(substitute( ~ foo,
-					   list(foo = x[[2]]))), fr)
-	nc <- ncol(mm)
-	nseq <- seq_len(nc)
-	sm <- as(ff, "sparseMatrix")
-	if (nc	> 1)
-	    sm <- do.call(rBind, lapply(nseq, function(i) sm))
-        ## hack for NA values contained in factor (FIXME: test elsewhere for consistency?)
-	sm@x[] <- t(mm[!is.na(ff),])
-	## When nc > 1 switch the order of the rows of sm
-	## so the random effects for the same level of the
-	## grouping factor are adjacent.
-	if (nc > 1)
-	    sm <- sm[as.vector(matrix(seq_len(nc * nl),
-				      ncol = nl, byrow = TRUE)),]
-	list(ff = ff, sm = sm, nl = nl, cnms = colnames(mm))
+  if (!length(bars))
+    stop("No random effects terms specified in formula")
+  stopifnot(is.list(bars), all(sapply(bars, is.language)),
+            inherits(fr, "data.frame"))
+  names(bars) <- unlist(lapply(bars, function(x) deparse(x[[3]])))
+  
+  ## auxiliary {named, for easier inspection}:
+  mkBlist <- function(x) {
+    frloc <- fr
+    ## convert grouping variables to factors as necessary
+    for (i in all.vars(x[[3]])) {
+      frloc[[i]] <- factor(frloc[[i]])
     }
-    blist <- lapply(bars, mkBlist)
-    nl <- unlist(lapply(blist, "[[", "nl")) # no. of levels per term
-
-    ## order terms stably by decreasing number of levels in the factor
-    if (any(diff(nl)) > 0) {
-	ord <- rev(order(nl))
-	blist <- blist[ord]
-	nl <- nl[ord]
-    }
-    Zt <- do.call(rBind, lapply(blist, "[[", "sm"))
-    q <- nrow(Zt)
-
-    ## Create and install Lambdat, Lind, etc.  This must be done after
-    ## any potential reordering of the terms.
-    cnms <- lapply(blist, "[[", "cnms")
-    nc <- sapply(cnms, length)		# no. of columns per term
-    nth <- as.integer((nc * (nc+1))/2)	# no. of parameters per term
-    nb <- nc * nl			# no. of random effects per term
-    stopifnot(sum(nb) == q)
-    boff <- cumsum(c(0L, nb))		# offsets into b
-    thoff <- cumsum(c(0L, nth))		# offsets into theta
-### FIXME: should this be done with cBind and avoid the transpose
-### operator?  In other words should Lambdat be generated directly
-### instead of generating Lambda first then transposing?
-    Lambdat <-
-	t(do.call(sparseMatrix,
-		  do.call(rBind,
-			  lapply(seq_along(blist), function(i)
-			     {
-				 mm <- matrix(seq_len(nb[i]), ncol = nc[i],
-					      byrow = TRUE)
-				 dd <- diag(nc[i])
-				 ltri <- lower.tri(dd, diag = TRUE)
-				 ii <- row(dd)[ltri]
-				 jj <- col(dd)[ltri]
-				 dd[cbind(ii, jj)] <- seq_along(ii)
-				 data.frame(i = as.vector(mm[, ii]) + boff[i],
-					    j = as.vector(mm[, jj]) + boff[i],
-					    x = as.double(rep.int(seq_along(ii),
-					    rep.int(nl[i], length(ii))) +
-					    thoff[i]))
-			     }))))
-    thet <- numeric(sum(nth))
-    ll <- list(Zt=Matrix::drop0(Zt), theta=thet, Lind=as.integer(Lambdat@x),
-               Gp=unname(c(0L, cumsum(nb))))
-    ## lower bounds on theta elements are 0 if on diagonal, else -Inf
-    ll$lower <- -Inf * (thet + 1)
-    ll$lower[unique(diag(Lambdat))] <- 0
-    ll$theta[] <- is.finite(ll$lower) # initial values of theta are 0 off-diagonal, 1 on
-    Lambdat@x[] <- ll$theta[ll$Lind]  # initialize elements of Lambdat
-    ll$Lambdat <- Lambdat
-					# massage the factor list
-    fl <- lapply(blist, "[[", "ff")
-					# check for repeated factors
-    fnms <- names(fl)
-    if (length(fnms) > length(ufn <- unique(fnms))) {
-	fl <- fl[match(ufn, fnms)]
-	asgn <- match(fnms, ufn)
-    } else asgn <- seq_along(fl)
-    names(fl) <- ufn
-    fl <- do.call(data.frame, c(fl, check.names = FALSE))
-    attr(fl, "assign") <- asgn
-    ll$flist <- fl
-    ll$cnms <- cnms
-    ll
+    ff <- eval(substitute(factor(fac), list(fac = x[[3]])), frloc)
+    if (all(is.na(ff)))
+      stop("Invalid grouping factor specification, ",
+           deparse(x[[3]]))
+    nl <- length(levels(ff))
+    mm <- model.matrix(eval(substitute( ~ foo,
+                                        list(foo = x[[2]]))), fr)
+    nc <- ncol(mm)
+    nseq <- seq_len(nc)
+    sm <- as(ff, "sparseMatrix")
+    if (nc	> 1)
+      sm <- do.call(rBind, lapply(nseq, function(i) sm))
+    ## hack for NA values contained in factor (FIXME: test elsewhere for consistency?)
+    sm@x[] <- t(mm[!is.na(ff),])
+    ## When nc > 1 switch the order of the rows of sm
+    ## so the random effects for the same level of the
+    ## grouping factor are adjacent.
+    if (nc > 1)
+      sm <- sm[as.vector(matrix(seq_len(nc * nl),
+                                ncol = nl, byrow = TRUE)),]
+    list(ff = ff, sm = sm, nl = nl, cnms = colnames(mm))
+  }
+  blist <- lapply(bars, mkBlist)
+  nl <- unlist(lapply(blist, "[[", "nl")) # no. of levels per term
+  
+  ## order terms stably by decreasing number of levels in the factor
+  if (any(diff(nl)) > 0) {
+    ord <- rev(order(nl))
+    blist <- blist[ord]
+    nl <- nl[ord]
+  }
+  Zt <- do.call(rBind, lapply(blist, "[[", "sm"))
+  q <- nrow(Zt)
+  
+  ## Create and install Lambdat, Lind, etc.  This must be done after
+  ## any potential reordering of the terms.
+  cnms <- lapply(blist, "[[", "cnms")
+  nc <- sapply(cnms, length)		# no. of columns per term
+  nth <- as.integer((nc * (nc+1))/2)	# no. of parameters per term
+  nb <- nc * nl			# no. of random effects per term
+  stopifnot(sum(nb) == q)
+  boff <- cumsum(c(0L, nb))		# offsets into b
+  thoff <- cumsum(c(0L, nth))		# offsets into theta
+  ### FIXME: should this be done with cBind and avoid the transpose
+  ### operator?  In other words should Lambdat be generated directly
+  ### instead of generating Lambda first then transposing?
+  Lambdat <-
+    t(do.call(sparseMatrix,
+              do.call(rBind,
+                      lapply(seq_along(blist), function(i)
+                      {
+                        mm <- matrix(seq_len(nb[i]), ncol = nc[i],
+                                     byrow = TRUE)
+                        dd <- diag(nc[i])
+                        ltri <- lower.tri(dd, diag = TRUE)
+                        ii <- row(dd)[ltri]
+                        jj <- col(dd)[ltri]
+                        dd[cbind(ii, jj)] <- seq_along(ii)
+                        data.frame(i = as.vector(mm[, ii]) + boff[i],
+                                   j = as.vector(mm[, jj]) + boff[i],
+                                   x = as.double(rep.int(seq_along(ii),
+                                                         rep.int(nl[i], length(ii))) +
+                                                   thoff[i]))
+                      }))))
+  thet <- numeric(sum(nth))
+  ll <- list(Zt=Matrix::drop0(Zt), theta=thet, Lind=as.integer(Lambdat@x),
+             Gp=unname(c(0L, cumsum(nb))))
+  ## lower bounds on theta elements are 0 if on diagonal, else -Inf
+  ll$lower <- -Inf * (thet + 1)
+  ll$lower[unique(diag(Lambdat))] <- 0
+  ll$theta[] <- is.finite(ll$lower) # initial values of theta are 0 off-diagonal, 1 on
+  Lambdat@x[] <- ll$theta[ll$Lind]  # initialize elements of Lambdat
+  ll$Lambdat <- Lambdat
+  # massage the factor list
+  fl <- lapply(blist, "[[", "ff")
+  # check for repeated factors
+  fnms <- names(fl)
+  if (length(fnms) > length(ufn <- unique(fnms))) {
+    fl <- fl[match(ufn, fnms)]
+    asgn <- match(fnms, ufn)
+  } else asgn <- seq_along(fl)
+  names(fl) <- ufn
+  fl <- do.call(data.frame, c(fl, check.names = FALSE))
+  attr(fl, "assign") <- asgn
+  ll$flist <- fl
+  ll$cnms <- cnms
+  ll
 } ## {mkReTrms}
 
 ##' Create an lmerResp, glmResp or nlsResp instance
@@ -143,7 +143,7 @@ mkReTrms <- function(bars, fr) {
 ##' @family utilities
 ##' @export
 mkRespMod <- function(fr, REML=NULL, family = NULL, nlenv = NULL, nlmod = NULL, ...) {
-
+  
   if(!missing(fr)){
     y <- model.response(fr)
     offset <- model.offset(fr)
@@ -159,70 +159,71 @@ mkRespMod <- function(fr, REML=NULL, family = NULL, nlenv = NULL, nlmod = NULL, 
     weights <- fr$weights
     etastart_update <- fr$etastart
   }
-
+  
   ## FIXME: may need to add X, or pass it somehow, if we want to use glm.fit
   #y <- model.response(fr)
-    if(length(dim(y)) == 1) {
-	## avoid problems with 1D arrays, but keep names
-	nm <- rownames(y)
-	dim(y) <- NULL
-	if(!is.null(nm)) names(y) <- nm
-    }
-    rho <- new.env()
-    rho$y <- if (is.null(y)) numeric(0) else y
-    if (!is.null(REML)) rho$REML <- REML
-    rho$etastart <- fr$etastart
-    rho$mustart <- fr$mustart
-    #N <- n <- nrow(fr)
-    if (!is.null(nlenv)) {
-        stopifnot(is.language(nlmod),
-                  is.environment(nlenv),
-                  is.numeric(val <- eval(nlmod, nlenv)),
-                  length(val) == n,
-                  is.matrix(gr <- attr(val, "gradient")),
-                  mode(gr) == "numeric",
-                  nrow(gr) == n,
-                  !is.null(pnames <- colnames(gr)))
-        N <- length(gr)
-        rho$mu <- as.vector(val)
-        rho$sqrtXwt <- as.vector(gr)
-        rho$gam <-
-            unname(unlist(lapply(pnames,
-                                 function(nm) get(nm, envir=nlenv))))
-    }
-    if (!is.null(offset)) {
-        if (length(offset) == 1L) offset <- rep.int(offset, N)
-        stopifnot(length(offset) == N)
-        rho$offset <- unname(offset)
-    } else rho$offset <- rep.int(0, N)
-    if (!is.null(weights)) {
-        stopifnot(length(weights) == n, all(weights >= 0))
-        rho$weights <- unname(weights)
-    } else rho$weights <- rep.int(1, n)
-    if (is.null(family)) {
-        if (is.null(nlenv)) return(do.call(lmerResp$new, as.list(rho)))
-        return(do.call(nlsResp$new,
-                       c(list(nlenv=nlenv,
-                              nlmod=substitute(~foo, list(foo=nlmod)),
-                              pnames=pnames), as.list(rho))))
-    }
-    stopifnot(inherits(family, "family"))
-                              # need weights for initialize evaluation
-    rho$nobs <- n
-    eval(family$initialize, rho)
-    family$initialize <- NULL     # remove clutter from str output
-    ll <- as.list(rho)
-    ans <- do.call(new, c(list(Class="glmResp", family=family),
-                          ll[setdiff(names(ll), c("m", "nobs", "mustart"))]))
+  if(length(dim(y)) == 1) {
+    ## avoid problems with 1D arrays, but keep names
+    nm <- rownames(y)
+    dim(y) <- NULL
+    if(!is.null(nm)) names(y) <- nm
+  }
+  rho <- new.env()
+  rho$y <- if (is.null(y)) numeric(0) else y
+  if (!is.null(REML)) rho$REML <- REML
+  rho$etastart <- fr$etastart
+  rho$mustart <- fr$mustart
+  #N <- n <- nrow(fr)
+  if (!is.null(nlenv)) {
+    stopifnot(is.language(nlmod),
+              is.environment(nlenv),
+              is.numeric(val <- eval(nlmod, nlenv)),
+              length(val) == n,
+              is.matrix(gr <- attr(val, "gradient")),
+              mode(gr) == "numeric",
+              nrow(gr) == n,
+              !is.null(pnames <- colnames(gr)))
+    N <- length(gr)
+    rho$mu <- as.vector(val)
+    rho$sqrtXwt <- as.vector(gr)
+    rho$gam <-
+      unname(unlist(lapply(pnames,
+                           function(nm) get(nm, envir=nlenv))))
+  }
+  if (!is.null(offset)) {
+    if (length(offset) == 1L) offset <- rep.int(offset, N)
+    stopifnot(length(offset) == N)
+    rho$offset <- unname(offset)
+  } else rho$offset <- rep.int(0, N)
+  if (!is.null(weights)) {
+    stopifnot(length(weights) == n, all(weights >= 0))
+    rho$weights <- unname(weights)
+  } else rho$weights <- rep.int(1, n)
+  if (is.null(family)) {
+    if (is.null(nlenv)) return(do.call(lmerResp$new, as.list(rho)))
+    return(do.call(nlsResp$new,
+                   c(list(nlenv=nlenv,
+                          nlmod=substitute(~foo, list(foo=nlmod)),
+                          pnames=pnames), as.list(rho))))
+  }
+  stopifnot(inherits(family, "family"))
+  # need weights for initialize evaluation
+  rho$nobs <- n
+  eval(family$initialize, rho)
+  family$initialize <- NULL     # remove clutter from str output
+  ll <- as.list(rho)
+  ans <- do.call(new, c(list(Class="glmResp", family=family),
+                        ll[setdiff(names(ll), c("m", "nobs", "mustart"))]))
   ans$updateMu(if (!is.null(es <- etastart_update)) es else
-                 family$linkfun(get("mustart", rho)))
-    ans
+    family$linkfun(get("mustart", rho)))
+  ans
 }
 
 ##' From the right hand side of a formula for a mixed-effects model,
 ##' determine the pairs of expressions that are separated by the
 ##' vertical bar operator.  Also expand the slash operator in grouping
-##' factor expressions.
+##' factor expressions and expand terms with the double vertical bar operator
+##' into separate, independent random effect terms.
 ##'
 ##' @title Determine random-effects expressions from a formula
 ##' @seealso \code{\link{formula}}, \code{\link{model.frame}}, \code{\link{model.matrix}}.
@@ -231,13 +232,15 @@ mkRespMod <- function(fr, REML=NULL, family = NULL, nlenv = NULL, nlmod = NULL, 
 ##' @section Note: This function is called recursively on individual
 ##' terms in the model, which is why the argument is called \code{term} and not
 ##' a name like \code{form}, indicating a formula.
-##' @examples
+##' @example
 ##' findbars(f1 <- Reaction ~ Days + (Days|Subject))
 ##' ## => list( Days | Subject )
 ##' findbars(y ~ Days + (1|Subject) + (0+Days|Subject))
 ##' ## => list of length 2:  list ( 1 | Subject ,  0+Days|Subject)
 ##' findbars(~ 1 + (1|batch/cask))
 ##' ## => list of length 2:  list ( 1 | cask:batch ,  1 | batch)
+##' identical(findbars(~ 1 + (Days || Subject)),
+##'     findbars(~ 1 + (1|Subject) + (0+Days|Subject))) 
 ##' \dontshow{
 ##' stopifnot(identical(findbars(f1),
 ##'                     list(expression(Days | Subject)[[1]])))
@@ -247,48 +250,87 @@ mkRespMod <- function(fr, REML=NULL, family = NULL, nlenv = NULL, nlmod = NULL, 
 ##' @export
 findbars <- function(term)
 {
-    ## Recursive function applied to individual terms
-    fb <- function(term)
+  expandDoubleVerts <- function(term)
+  {
+    if (is.name(term) || !is.language(term)) return(term)
+    if (term[[1]] == as.name("(")) {
+      term[[2]] <- expandDoubleVerts(term[[2]])
+      return(term)
+    }  
+    stopifnot(is.call(term))
+    if (term[[1]] == as.name('||')) {
+      term <- expandDoubleVert(term)
+      return(term)
+    } 
+    if (length(term) == 2){
+      term[[2]] <- expandDoubleVerts(term[[2]])
+      return(term)
+    } 
+    term[[2]] <- expandDoubleVerts(term[[2]])
+    if(length(term) == 3){ 
+      term[[3]] <- expandDoubleVerts(term[[3]])
+    }  
+    term
+  }
+  
+  expandDoubleVert <- function(term){
+    frml <- formula(paste0("~", deparse(term[[2]])))
+    #need term.labels not all.vars to capture interactions too:
+    newtrms <- paste0("0+", attr(terms(frml), "term.labels"))
+    
+    if(attr(terms(frml), "intercept")!=0) newtrms <- c("1", newtrms)
+    
+    as.name(paste(sapply(newtrms, function(trm){
+      paste0(trm, "|", deparse(term[[3]]))  
+    }), collapse=")+("))
+  }  
+  
+  
+  ## Recursive function applied to individual terms
+  fb <- function(term)
+  {
+    if (is.name(term) || !is.language(term)) return(NULL)
+    if (term[[1]] == as.name("(")) return(fb(term[[2]]))
+    stopifnot(is.call(term))
+    if (term[[1]] == as.name('|')) return(term)
+    if (length(term) == 2) return(fb(term[[2]]))
+    c(fb(term[[2]]), fb(term[[3]]))
+  }
+  ## Expand any slashes in the grouping factors returned by fb
+  expandSlash <- function(bb)
+  {
+    ## Create the interaction terms for nested effects
+    makeInteraction <- function(x)
     {
-        if (is.name(term) || !is.language(term)) return(NULL)
-        if (term[[1]] == as.name("(")) return(fb(term[[2]]))
-        stopifnot(is.call(term))
-        if (term[[1]] == as.name('|')) return(term)
-        if (length(term) == 2) return(fb(term[[2]]))
-        c(fb(term[[2]]), fb(term[[3]]))
+      if (length(x) < 2) return(x)
+      trm1 <- makeInteraction(x[[1]])
+      trm11 <- if(is.list(trm1)) trm1[[1]] else trm1
+      list(substitute(foo:bar, list(foo=x[[2]], bar = trm11)), trm1)
     }
-    ## Expand any slashes in the grouping factors returned by fb
-    expandSlash <- function(bb)
+    ## Return the list of '/'-separated terms
+    slashTerms <- function(x)
     {
-        ## Create the interaction terms for nested effects
-        makeInteraction <- function(x)
-        {
-            if (length(x) < 2) return(x)
-            trm1 <- makeInteraction(x[[1]])
-            trm11 <- if(is.list(trm1)) trm1[[1]] else trm1
-            list(substitute(foo:bar, list(foo=x[[2]], bar = trm11)), trm1)
-        }
-        ## Return the list of '/'-separated terms
-        slashTerms <- function(x)
-        {
-            if (!("/" %in% all.names(x))) return(x)
-            if (x[[1]] != as.name("/"))
-                stop("unparseable formula for grouping factor")
-            list(slashTerms(x[[2]]), slashTerms(x[[3]]))
-        }
+      if (!("/" %in% all.names(x))) return(x)
+      if (x[[1]] != as.name("/"))
+        stop("unparseable formula for grouping factor")
+      list(slashTerms(x[[2]]), slashTerms(x[[3]]))
+    }
+    
+    if (!is.list(bb)) return(expandSlash(list(bb)))
+    ## lapply(unlist(... - unlist returns a flattened list
+    unlist(lapply(bb, function(x) {
+      if (length(x) > 2 && is.list(trms <- slashTerms(x[[3]])))
+        return(lapply(unlist(makeInteraction(trms)),
+                      function(trm) substitute(foo|bar,
+                                               list(foo = x[[2]],
+                                                    bar = trm))))
+      x
+    }))
+  }
 
-        if (!is.list(bb)) return(expandSlash(list(bb)))
-        ## lapply(unlist(... - unlist returns a flattened list
-        unlist(lapply(bb, function(x) {
-            if (length(x) > 2 && is.list(trms <- slashTerms(x[[3]])))
-                return(lapply(unlist(makeInteraction(trms)),
-                              function(trm) substitute(foo|bar,
-                                                       list(foo = x[[2]],
-                                                            bar = trm))))
-            x
-        }))
-    }
-    expandSlash(fb(term))
+  modterm <- as.formula(paste("~", gsub("`", "",
+                                        deparse(expandDoubleVerts(term)))))
+  expandSlash(fb(modterm))
 }
 
 ##' Remove the random-effects terms from a mixed-effects formula,
@@ -308,30 +350,31 @@ findbars <- function(term)
 ##' @export
 nobars <- function(term)
 {
-    if (!('|' %in% all.names(term))) return(term)
-    if (is.call(term) && term[[1]] == as.name('|')) return(NULL)
-    if (length(term) == 2) {
-	nb <- nobars(term[[2]])
-	if (is.null(nb)) return(NULL)
-	term[[2]] <- nb
-	return(term)
-    }
-    nb2 <- nobars(term[[2]])
-    nb3 <- nobars(term[[3]])
-    if (is.null(nb2)) return(nb3)
-    if (is.null(nb3)) return(nb2)
-    term[[2]] <- nb2
-    term[[3]] <- nb3
-    term
+  if (!any(c('|','||') %in% all.names(term))) return(term)
+  if (is.call(term) && term[[1]] == as.name('|')) return(NULL)
+  if (is.call(term) && term[[1]] == as.name('||')) return(NULL)
+  if (length(term) == 2) {
+    nb <- nobars(term[[2]])
+    if (is.null(nb)) return(NULL)
+    term[[2]] <- nb
+    return(term)
+  }
+  nb2 <- nobars(term[[2]])
+  nb3 <- nobars(term[[3]])
+  if (is.null(nb2)) return(nb3)
+  if (is.null(nb3)) return(nb2)
+  term[[2]] <- nb2
+  term[[3]] <- nb3
+  term
 }
 
-##' Substitute the '+' function for the '|' function in a mixed-model
+##' Substitute the '+' function for the '|' and '||' function in a mixed-model
 ##' formula.  This provides a formula suitable for the current
 ##' model.frame function.
 ##'
 ##' @title "Sub[stitute] Bars"
 ##' @param term a mixed-model formula
-##' @return the formula with all | operators replaced by +
+##' @return the formula with all |  and || operators replaced by +
 ##' @section Note: This function is called recursively on individual
 ##' terms in the model, which is why the argument is called \code{term} and not
 ##' a name like \code{form}, indicating a formula.
@@ -343,16 +386,18 @@ nobars <- function(term)
 ##' @export
 subbars <- function(term)
 {
-    if (is.name(term) || !is.language(term)) return(term)
-    if (length(term) == 2) {
-	term[[2]] <- subbars(term[[2]])
-	return(term)
-    }
-    stopifnot(length(term) >= 3)
-    if (is.call(term) && term[[1]] == as.name('|'))
-	term[[1]] <- as.name('+')
-    for (j in 2:length(term)) term[[j]] <- subbars(term[[j]])
-    term
+  if (is.name(term) || !is.language(term)) return(term)
+  if (length(term) == 2) {
+    term[[2]] <- subbars(term[[2]])
+    return(term)
+  }
+  stopifnot(length(term) >= 3)
+  if (is.call(term) && term[[1]] == as.name('|'))
+    term[[1]] <- as.name('+')
+  if (is.call(term) && term[[1]] == as.name('||'))
+    term[[1]] <- as.name('+')
+  for (j in 2:length(term)) term[[j]] <- subbars(term[[j]])
+  term
 }
 
 ##' Does every level of f1 occur in conjunction with exactly one level
@@ -372,38 +417,38 @@ subbars <- function(term)
 ##' @export
 isNested <- function(f1, f2)
 {
-    f1 <- as.factor(f1)
-    f2 <- as.factor(f2)
-    stopifnot(length(f1) == length(f2))
-    k <- length(levels(f1))
-    sm <- as(new("ngTMatrix",
-		 i = as.integer(f2) - 1L,
-		 j = as.integer(f1) - 1L,
-		 Dim = c(length(levels(f2)), k)),
-             "CsparseMatrix")
-    all(sm@p[2:(k+1L)] - sm@p[1:k] <= 1L)
+  f1 <- as.factor(f1)
+  f2 <- as.factor(f2)
+  stopifnot(length(f1) == length(f2))
+  k <- length(levels(f1))
+  sm <- as(new("ngTMatrix",
+               i = as.integer(f2) - 1L,
+               j = as.integer(f1) - 1L,
+               Dim = c(length(levels(f2)), k)),
+           "CsparseMatrix")
+  all(sm@p[2:(k+1L)] - sm@p[1:k] <= 1L)
 }
 
 subnms <- function(form, nms) {
-    ## Recursive function applied to individual terms
-    sbnm <- function(term)
-    {
-        if (is.name(term))
-            if (any(term == nms)) return(0) else return(term)
-        switch(length(term),
-               return(term),
-           {
-               term[[2]] <- sbnm(term[[2]])
-               return(term)
-           },
-           {
-               term[[2]] <- sbnm(term[[2]])
-               term[[3]] <- sbnm(term[[3]])
-               return(term)
-           })
-        NULL
-    }
-    sbnm(form)
+  ## Recursive function applied to individual terms
+  sbnm <- function(term)
+  {
+    if (is.name(term))
+      if (any(term == nms)) return(0) else return(term)
+    switch(length(term),
+           return(term),
+{
+  term[[2]] <- sbnm(term[[2]])
+  return(term)
+},
+{
+  term[[2]] <- sbnm(term[[2]])
+  term[[3]] <- sbnm(term[[3]])
+  return(term)
+})
+    NULL
+  }
+  sbnm(form)
 }
 
 ## Check for a constant term (a literal 1) in an expression
@@ -417,11 +462,11 @@ subnms <- function(form, nms) {
 ## @param expr an expression
 ## @return NULL.  The function is executed for its side effect.
 chck1 <- function(expr) {
-    if ((le <- length(expr)) == 1) {
-        if (is.numeric(expr) && expr == 1)
-            stop("1 is not meaningful in a nonlinear model formula")
-        return()
-    } else
+  if ((le <- length(expr)) == 1) {
+    if (is.numeric(expr) && expr == 1)
+      stop("1 is not meaningful in a nonlinear model formula")
+    return()
+  } else
     for (j in seq_len(le)[-1]) Recall(expr[[j]])
 }
 
@@ -461,47 +506,47 @@ chck1 <- function(expr) {
 ##' @export
 ##' @family utilities
 nlformula <- function(mc) {
-    start <- eval(mc$start, parent.frame(2L))
-    if (is.numeric(start)) start <- list(nlpars = start)
-    stopifnot(is.numeric(nlpars <- start$nlpars),
-              all(sapply(nlpars, length) == 1L),
-              length(pnames <- names(nlpars)) == length(nlpars),
-              length(form <- as.formula(mc$formula)) == 3L,
-              is(nlform <- eval(form[[2]]), "formula"),
-              all(pnames %in%
+  start <- eval(mc$start, parent.frame(2L))
+  if (is.numeric(start)) start <- list(nlpars = start)
+  stopifnot(is.numeric(nlpars <- start$nlpars),
+            all(sapply(nlpars, length) == 1L),
+            length(pnames <- names(nlpars)) == length(nlpars),
+            length(form <- as.formula(mc$formula)) == 3L,
+            is(nlform <- eval(form[[2]]), "formula"),
+            all(pnames %in%
                   (av <- all.vars(nlmod <- as.call(nlform[[lnl <- length(nlform)]])))))
-    nlform[[lnl]] <- parse(text= paste(setdiff(all.vars(form), pnames), collapse=' + '))[[1]]
-    nlform <- eval(nlform)
-    environment(nlform) <- environment(form)
-    m <- match(c("data", "subset", "weights", "na.action", "offset"),
-	       names(mc), 0)
-    mc <- mc[c(1, m)]
-    mc$drop.unused.levels <- TRUE
-    mc[[1]] <- as.name("model.frame")
-    mc$formula <- nlform
-    fr <- eval(mc, parent.frame(2L))
-    n <- nrow(fr)
-    nlenv <- list2env(fr, parent=parent.frame(2L))
-    lapply(pnames, function(nm) nlenv[[nm]] <- rep.int(nlpars[[nm]], n))
-    respMod <- mkRespMod(fr, nlenv=nlenv, nlmod=nlmod)
-
-    chck1(meform <- form[[3L]])
-    pnameexpr <- parse(text=paste(pnames, collapse='+'))[[1]]
-    nb <- nobars(meform)
-    fe <- eval(substitute(~ 0 + nb + pnameexpr))
-    environment(fe) <- environment(form)
-    frE <- do.call(rbind, lapply(seq_along(nlpars), function(i) fr)) # rbind s copies of the frame
-    for (nm in pnames) # convert these variables in fr to indicators
-	frE[[nm]] <- as.numeric(rep(nm == pnames, each = n))
-    X <- model.matrix(fe, frE)
-    rownames(X) <- NULL
-
-    reTrms <- mkReTrms(lapply(findbars(meform),
-                              function(expr) {
-                                  expr[[2]] <- substitute(0+foo, list(foo=expr[[2]]))
-                                  expr
-                              }), frE)
-    list(respMod=respMod, frame=fr, X=X, reTrms=reTrms, pnames=pnames)
+  nlform[[lnl]] <- parse(text= paste(setdiff(all.vars(form), pnames), collapse=' + '))[[1]]
+  nlform <- eval(nlform)
+  environment(nlform) <- environment(form)
+  m <- match(c("data", "subset", "weights", "na.action", "offset"),
+             names(mc), 0)
+  mc <- mc[c(1, m)]
+  mc$drop.unused.levels <- TRUE
+  mc[[1]] <- as.name("model.frame")
+  mc$formula <- nlform
+  fr <- eval(mc, parent.frame(2L))
+  n <- nrow(fr)
+  nlenv <- list2env(fr, parent=parent.frame(2L))
+  lapply(pnames, function(nm) nlenv[[nm]] <- rep.int(nlpars[[nm]], n))
+  respMod <- mkRespMod(fr, nlenv=nlenv, nlmod=nlmod)
+  
+  chck1(meform <- form[[3L]])
+  pnameexpr <- parse(text=paste(pnames, collapse='+'))[[1]]
+  nb <- nobars(meform)
+  fe <- eval(substitute(~ 0 + nb + pnameexpr))
+  environment(fe) <- environment(form)
+  frE <- do.call(rbind, lapply(seq_along(nlpars), function(i) fr)) # rbind s copies of the frame
+  for (nm in pnames) # convert these variables in fr to indicators
+    frE[[nm]] <- as.numeric(rep(nm == pnames, each = n))
+  X <- model.matrix(fe, frE)
+  rownames(X) <- NULL
+  
+  reTrms <- mkReTrms(lapply(findbars(meform),
+                            function(expr) {
+                              expr[[2]] <- substitute(0+foo, list(foo=expr[[2]]))
+                              expr
+                            }), frE)
+  list(respMod=respMod, frame=fr, X=X, reTrms=reTrms, pnames=pnames)
 }
 
 ##' Create an object in a subclass of \code{\linkS4class{merMod}}
@@ -517,95 +562,95 @@ nlformula <- function(mc) {
 ##' @return an object from a class that inherits from \code{\linkS4class{merMod}}
 ##' @export
 mkMerMod <- function(rho, opt, reTrms, fr, mc) {
-    if(missing(mc)) mc <- match.call()
-    stopifnot(is.environment(rho),
-              is(pp <- rho$pp, "merPredD"),
-              is(resp <- rho$resp, "lmResp"),
-              is.list(opt),
-              "par" %in% names(opt),
-              all(c("conv","fval") %in% substr(names(opt),1,4)), ## "conv[ergence]", "fval[ues]"
-              is.list(reTrms),
-              all(c("flist", "cnms", "Gp", "lower") %in%
+  if(missing(mc)) mc <- match.call()
+  stopifnot(is.environment(rho),
+            is(pp <- rho$pp, "merPredD"),
+            is(resp <- rho$resp, "lmResp"),
+            is.list(opt),
+            "par" %in% names(opt),
+            all(c("conv","fval") %in% substr(names(opt),1,4)), ## "conv[ergence]", "fval[ues]"
+            is.list(reTrms),
+            all(c("flist", "cnms", "Gp", "lower") %in%
                   names(reTrms)))
-    rcl  <- class(resp)
-    n    <- nrow(pp$V)
-    p    <- ncol(pp$V)
-    dims <- c(N=nrow(pp$X), n=n, p=p, nmp=n-p,
-              nth=length(pp$theta), q=nrow(pp$Zt),
-              nAGQ=rho$nAGQ,
-              compDev=rho$compDev,
-              ## 'use scale' in the sense of whether dispersion parameter should
-              ##  be reported/used (*not* whether theta should be scaled by sigma)
-              useSc=(rcl != "glmResp" ||
+  rcl  <- class(resp)
+  n    <- nrow(pp$V)
+  p    <- ncol(pp$V)
+  dims <- c(N=nrow(pp$X), n=n, p=p, nmp=n-p,
+            nth=length(pp$theta), q=nrow(pp$Zt),
+            nAGQ=rho$nAGQ,
+            compDev=rho$compDev,
+            ## 'use scale' in the sense of whether dispersion parameter should
+            ##  be reported/used (*not* whether theta should be scaled by sigma)
+            useSc=(rcl != "glmResp" ||
                      !resp$family$family %in% c("poisson","binomial")),
-              reTrms=length(reTrms$cnms),
-              spFe=0L,
-              REML=if (rcl=="lmerResp") resp$REML else 0L,
-              GLMM=(rcl=="glmResp"),
-              NLMM=(rcl=="nlsResp"))
-    storage.mode(dims) <- "integer"
-    fac     <- as.numeric(rcl != "nlsResp")
-    sqrLenU <- pp$sqrL(fac)
-    wrss    <- resp$wrss()
-    pwrss   <- wrss + sqrLenU
-    weights <- resp$weights
-    beta    <- pp$beta(fac)
-    sigmaML <- pwrss/sum(weights)
-    if (rcl != "lmerResp") {
-        pars <- opt$par
-        if (length(pars) > length(pp$theta)) beta <- pars[-(seq_along(pp$theta))]
-    }
-    cmp <- c(ldL2=pp$ldL2(), ldRX2=pp$ldRX2(), wrss=wrss,
-             ussq=sqrLenU, pwrss=pwrss,
-             drsum=if (rcl=="glmResp") resp$resDev() else NA,
-             REML=if (rcl=="lmerResp" && resp$REML != 0L) opt$fval else NA,
-             ## FIXME: construct 'REML deviance' here?
-             dev=if (rcl=="lmerResp" && resp$REML != 0L) NA else opt$fval,
-             sigmaML=sqrt(unname(if (!dims["useSc"]) NA else sigmaML)),
-             sigmaREML=sqrt(unname(if (rcl!="lmerResp") NA else sigmaML*(dims['n']/dims['nmp']))),
-             tolPwrss=rho$tolPwrss)
-    # TODO:  improve this hack to get something in frame slot (maybe need weights, etc...)
-    if(missing(fr)) fr <- data.frame(resp$y)
-    new(switch(rcl, lmerResp="lmerMod", glmResp="glmerMod", nlsResp="nlmerMod"),
-        call=mc, frame=fr, flist=reTrms$flist, cnms=reTrms$cnms,
-        Gp=reTrms$Gp, theta=pp$theta, beta=beta, u=pp$u(fac),
-        lower=reTrms$lower, devcomp=list(cmp=cmp, dims=dims), pp=pp, resp=resp,
-        optinfo=list(optimizer=attr(opt,"optimizer"),
-                     control=attr(opt,"control"),
-                     conv=opt$conv,
-                     warnings=attr(opt,"warnings"))
-        )
+            reTrms=length(reTrms$cnms),
+            spFe=0L,
+            REML=if (rcl=="lmerResp") resp$REML else 0L,
+            GLMM=(rcl=="glmResp"),
+            NLMM=(rcl=="nlsResp"))
+  storage.mode(dims) <- "integer"
+  fac     <- as.numeric(rcl != "nlsResp")
+  sqrLenU <- pp$sqrL(fac)
+  wrss    <- resp$wrss()
+  pwrss   <- wrss + sqrLenU
+  weights <- resp$weights
+  beta    <- pp$beta(fac)
+  sigmaML <- pwrss/sum(weights)
+  if (rcl != "lmerResp") {
+    pars <- opt$par
+    if (length(pars) > length(pp$theta)) beta <- pars[-(seq_along(pp$theta))]
+  }
+  cmp <- c(ldL2=pp$ldL2(), ldRX2=pp$ldRX2(), wrss=wrss,
+           ussq=sqrLenU, pwrss=pwrss,
+           drsum=if (rcl=="glmResp") resp$resDev() else NA,
+           REML=if (rcl=="lmerResp" && resp$REML != 0L) opt$fval else NA,
+           ## FIXME: construct 'REML deviance' here?
+           dev=if (rcl=="lmerResp" && resp$REML != 0L) NA else opt$fval,
+           sigmaML=sqrt(unname(if (!dims["useSc"]) NA else sigmaML)),
+           sigmaREML=sqrt(unname(if (rcl!="lmerResp") NA else sigmaML*(dims['n']/dims['nmp']))),
+           tolPwrss=rho$tolPwrss)
+  # TODO:  improve this hack to get something in frame slot (maybe need weights, etc...)
+  if(missing(fr)) fr <- data.frame(resp$y)
+  new(switch(rcl, lmerResp="lmerMod", glmResp="glmerMod", nlsResp="nlmerMod"),
+      call=mc, frame=fr, flist=reTrms$flist, cnms=reTrms$cnms,
+      Gp=reTrms$Gp, theta=pp$theta, beta=beta, u=pp$u(fac),
+      lower=reTrms$lower, devcomp=list(cmp=cmp, dims=dims), pp=pp, resp=resp,
+      optinfo=list(optimizer=attr(opt,"optimizer"),
+                   control=attr(opt,"control"),
+                   conv=opt$conv,
+                   warnings=attr(opt,"warnings"))
+  )
 }
 
 ## generic argument checking
 ## 'type': name of calling function ("glmer", "lmer", "nlmer")
 ##
 checkArgs <- function(type,...) {
-    l... <- list(...)
-    if (isTRUE(l...[["sparseX"]])) warning("sparseX = TRUE has no effect at present")
-    ## '...' handling up front, safe-guarding against typos ("familiy") :
-    if(length(l... <- list(...))) {
-        if (!is.null(l...[["family"]])) {  # call glmer if family specified
-            ## we will only get here if 'family' is *not* in the arg list
-            warning("calling lmer with family() is deprecated: please use glmer() instead")
-            type <- "glmer"
-        }
-        ## Check for method argument which is no longer used
-        ## (different meanings/hints depending on glmer vs lmer)
-        if (!is.null(method <- l...[["method"]])) {
-            msg <- paste("Argument", sQuote("method"), "is deprecated.")
-            if (type=="lmer") msg <- paste(msg,"Use the REML argument to specify ML or REML estimation.")
-            if (type=="glmer") msg <- paste(msg,"Use the nAGQ argument to specify Laplace (nAGQ=1) or adaptive",
-                "Gauss-Hermite quadrature (nAGQ>1).  PQL is no longer available.")
-            warning(msg)
-            l... <- l...[names(l...) != "method"]
-        }
-        if(length(l...)) {
-            warning("extra argument(s) ",
-                    paste(sQuote(names(l...)), collapse=", "),
-                    " disregarded")
-        }
+  l... <- list(...)
+  if (isTRUE(l...[["sparseX"]])) warning("sparseX = TRUE has no effect at present")
+  ## '...' handling up front, safe-guarding against typos ("familiy") :
+  if(length(l... <- list(...))) {
+    if (!is.null(l...[["family"]])) {  # call glmer if family specified
+      ## we will only get here if 'family' is *not* in the arg list
+      warning("calling lmer with family() is deprecated: please use glmer() instead")
+      type <- "glmer"
     }
+    ## Check for method argument which is no longer used
+    ## (different meanings/hints depending on glmer vs lmer)
+    if (!is.null(method <- l...[["method"]])) {
+      msg <- paste("Argument", sQuote("method"), "is deprecated.")
+      if (type=="lmer") msg <- paste(msg,"Use the REML argument to specify ML or REML estimation.")
+      if (type=="glmer") msg <- paste(msg,"Use the nAGQ argument to specify Laplace (nAGQ=1) or adaptive",
+                                      "Gauss-Hermite quadrature (nAGQ>1).  PQL is no longer available.")
+      warning(msg)
+      l... <- l...[names(l...) != "method"]
+    }
+    if(length(l...)) {
+      warning("extra argument(s) ",
+              paste(sQuote(names(l...)), collapse=", "),
+              " disregarded")
+    }
+  }
 }
 
 ## check formula and data: return an environment suitable for evaluating
@@ -618,73 +663,73 @@ checkArgs <- function(type,...) {
 ## this may fail ...
 
 checkFormulaData <- function(formula,data,debug=FALSE) {
-    dataName <- deparse(substitute(data))
-    missingData <- inherits(tryCatch(eval(data), error=function(e)e), "error")
-    ## data not found (this *should* only happen with garbage input,
-    ## OR when strings used as formulae -> drop1/update/etc.)
-    ##
-    ## alternate attempt (fails)
-    ##
-    ## ff <- sys.frames()
-    ## ex <- substitute(data)
-    ## ii <- rev(seq_along(ff))
-    ## for(i in ii) {
-    ##     ex <- eval(substitute(substitute(x, env=sys.frames()[[n]]),
-    ##                           env = list(x = ex, n=i)))
-    ## }
-    ## origName <- deparse(ex)
-    ## missingData <- !exists(origName)
-    ## (!dataName=="NULL" && !exists(dataName))
-    if (missingData) {
-        varex <- function(v,env) exists(v,envir=env,inherits=FALSE)
-        allvars <- all.vars(as.formula(formula))
-        allvarex <- function(vvec=allvars,...) { all(sapply(vvec,varex,...)) }
-        if (allvarex(env=(ee <- environment(formula)))) {
-            stop("'data' not found, but variables found in environment of formula: ",
-                    "try specifying 'formula' as a formula rather ",
-                    "than a string in the original model")
-        } else stop("'data' not found, and some variables missing from formula environment")
+  dataName <- deparse(substitute(data))
+  missingData <- inherits(tryCatch(eval(data), error=function(e)e), "error")
+  ## data not found (this *should* only happen with garbage input,
+  ## OR when strings used as formulae -> drop1/update/etc.)
+  ##
+  ## alternate attempt (fails)
+  ##
+  ## ff <- sys.frames()
+  ## ex <- substitute(data)
+  ## ii <- rev(seq_along(ff))
+  ## for(i in ii) {
+  ##     ex <- eval(substitute(substitute(x, env=sys.frames()[[n]]),
+  ##                           env = list(x = ex, n=i)))
+  ## }
+  ## origName <- deparse(ex)
+  ## missingData <- !exists(origName)
+  ## (!dataName=="NULL" && !exists(dataName))
+  if (missingData) {
+    varex <- function(v,env) exists(v,envir=env,inherits=FALSE)
+    allvars <- all.vars(as.formula(formula))
+    allvarex <- function(vvec=allvars,...) { all(sapply(vvec,varex,...)) }
+    if (allvarex(env=(ee <- environment(formula)))) {
+      stop("'data' not found, but variables found in environment of formula: ",
+           "try specifying 'formula' as a formula rather ",
+           "than a string in the original model")
+    } else stop("'data' not found, and some variables missing from formula environment")
+  } else {
+    if (is.null(data)) {
+      if (!is.null(ee <- environment(formula))) {
+        ## use environment of formula
+        denv <- ee
+      } else {
+        ## e.g. no environment, e.g. because formula is a character vector
+        ## parent.frame(2L) works because [g]lFormula (our calling environment)
+        ## has been called within [g]lmer with env=parent.frame(1L)
+        ## If you call checkFormulaData in some other bizarre way such that
+        ## parent.frame(2L) is *not* OK, you deserve what you get
+        ## calling checkFormulaData directly from the global
+        ## environment should be OK, since trying to go up beyond the global
+        ## environment keeps bringing you back to the global environment ...
+        denv <- parent.frame(2L)
+      }
     } else {
-        if (is.null(data)) {
-            if (!is.null(ee <- environment(formula))) {
-                ## use environment of formula
-                denv <- ee
-            } else {
-                ## e.g. no environment, e.g. because formula is a character vector
-                ## parent.frame(2L) works because [g]lFormula (our calling environment)
-                ## has been called within [g]lmer with env=parent.frame(1L)
-                ## If you call checkFormulaData in some other bizarre way such that
-                ## parent.frame(2L) is *not* OK, you deserve what you get
-                ## calling checkFormulaData directly from the global
-                ## environment should be OK, since trying to go up beyond the global
-                ## environment keeps bringing you back to the global environment ...
-                denv <- parent.frame(2L)
-            }
-        } else {
-            ## data specified
-            denv <- list2env(data)
-        }
+      ## data specified
+      denv <- list2env(data)
     }
-    ## FIXME: set enclosing environment of denv to environment(formula), or parent.frame(2L) ?
-    if (debug) {
-        cat("Debugging parent frames in checkFormulaData:\n")
-        ## find global environment -- could do this with sys.nframe() ?
-        glEnv <- 1
-        while (!identical(parent.frame(glEnv),.GlobalEnv)) {
-            glEnv <- glEnv+1
-        }
-        ## where are vars?
-        for (i in 1:glEnv) {
-            OK <- allvarex(env=parent.frame(i))
-            cat("vars exist in parent frame ",i)
-            if (i==glEnv) cat(" (global)")
-            cat(" ",OK,"\n")
-        }
-        cat("vars exist in env of formula ",allvarex(env=denv),"\n")
-    } ## if (debug)
-
-    stopifnot(length(as.formula(formula,env=denv)) == 3)  ## check for two-sided formula
-    return(denv)
+  }
+  ## FIXME: set enclosing environment of denv to environment(formula), or parent.frame(2L) ?
+  if (debug) {
+    cat("Debugging parent frames in checkFormulaData:\n")
+    ## find global environment -- could do this with sys.nframe() ?
+    glEnv <- 1
+    while (!identical(parent.frame(glEnv),.GlobalEnv)) {
+      glEnv <- glEnv+1
+    }
+    ## where are vars?
+    for (i in 1:glEnv) {
+      OK <- allvarex(env=parent.frame(i))
+      cat("vars exist in parent frame ",i)
+      if (i==glEnv) cat(" (global)")
+      cat(" ",OK,"\n")
+    }
+    cat("vars exist in env of formula ",allvarex(env=denv),"\n")
+  } ## if (debug)
+  
+  stopifnot(length(as.formula(formula,env=denv)) == 3)  ## check for two-sided formula
+  return(denv)
 }
 
 ## checkFormulaData <- function(formula,data) {

--- a/tests/doubleVertNotation.R
+++ b/tests/doubleVertNotation.R
@@ -1,0 +1,46 @@
+# testing "||" notation for independent ranefs
+#setwd("C:/birs/lme4")
+
+library(testthat)
+library(devtools)
+
+rm(list=ls())
+load_all()
+
+#basic intercept + slope
+expect_equivalent(
+  lFormula(Reaction ~ Days + (Days||Subject), sleepstudy)$reTrms,
+  lFormula(Reaction ~ Days + (1|Subject) + (0 + Days|Subject), sleepstudy)$reTrms,
+)  
+
+expect_equivalent(
+  fitted(lmer(Reaction ~ Days + (Days||Subject), sleepstudy)),
+  fitted(lmer(Reaction ~ Days + (1|Subject) + (0 + Days|Subject), sleepstudy)),
+)  
+
+
+#works with nested
+expect_equivalent(findbars(y ~ (x || id / id2)),
+                  findbars(y ~ (1 | id  / id2) + (0 + x | id / id2)))
+
+#works with multiple
+expect_equivalent(findbars(y ~ (x1 + x2  || id / id2) + (x3 | id3) + (x4 || id4)),
+                  findbars(y ~ (1 | id / id2) + (0 + x1 | id / id2) +
+                             (0 + x2 | id / id2) + (x3 | id3) + (1 | id4) + 
+                             (0 + x4| id4)))
+
+# leaves superfluous || alone:
+expect_equivalent(findbars(y ~ z + (0 + x || id)),
+                  findbars(y ~ z + (0 + x  | id)))
+
+# plays nice with parens in fixed formula:
+expect_equivalent(findbars(y ~ (z + x)^2 + (x || id)),
+                  findbars(y ~ (z + x)^2 + (1 | id) + (0 + x | id)))
+
+# works for interactions:
+expect_equivalent(findbars(y ~ (x1*x2 || id)),
+                  findbars(y ~ (1 | id) + (0+x1 | id) + (0 + x2 | id) +
+                             (0 + x1:x2 | id)))
+      
+                
+                  


### PR DESCRIPTION
Sorry about the huge diff, I didn't realize all the changes in indentation would show up, too --
please dont Ripley me, I'm almost a github virgin..

The only real changes are in `utilities.R` in functions
- `findbars()`
- `subbars()`
- `nobars()`.

That
`modterm <- as.formula(paste("~", gsub("`", "", deparse(expandDoubleVerts(term)))))`
part is admittedly very ugly, but I just couldn't find a way to make it more appealing...
