### PR TITLE
Remove date from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,5 @@
 Package: lme4
 Version: 1.1-0
-Date: 2013-08-17
 Title: Linear mixed-effects models using Eigen and S4
 Authors@R: c(person("Douglas","Bates",
     role="aut"),


### PR DESCRIPTION
I think this is good practice because it avoids inconsistencies, and CRAN-building adds the actual date built.
