### PR TITLE
Ensuring X is of full rank

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: lme4
-Version: 1.1-0
+Version: 1.1-1
 Title: Linear mixed-effects models using Eigen and S4
 Authors@R: c(person("Douglas","Bates",
     role="aut"),

--- a/R/lmer.R
+++ b/R/lmer.R
@@ -711,7 +711,7 @@ anovaLmer <- function(object, ...) {
 	ss <- as.vector(object@pp$RX() %*% object@beta)^2
 	names(ss) <- colnames(X)
 	terms <- terms(object)
-        nmeffects <- attr(terms, "term.labels")
+        nmeffects <- attr(terms, "term.labels")[unique(asgn)]
 	if ("(Intercept)" %in% names(ss))
 	    nmeffects <- c("(Intercept)", nmeffects)
 	ss <- unlist(lapply(split(ss, asgn), sum))
@@ -1186,10 +1186,10 @@ refit.merMod <- function(object, newresp=NULL, rename.response=FALSE, ...)
     if (length(list(...))>0) warning("additional arguments to refit.merMod ignored")
     ## TODO: not clear whether we should reset the names
     ##       to the new response variable.  Maybe not.
-    
+
     ## retrieve name before it gets mangled by operations on newresp
     newrespSub <- substitute(newresp)
-    
+
     ## for backward compatibility/functioning of refit(fit,simulate(fit))
     if (is.list(newresp)) {
         if (length(newresp)==1) {

--- a/R/lmerControl.R
+++ b/R/lmerControl.R
@@ -48,6 +48,7 @@ namedList <- function(...) {
 ## add better logic for distinguishing whether the scale parameter is
 ## being estimated
 ##' @param check.nobs.vs.nlev character - rules for checking whether the number of observations is less than (or less than or equal to) the number of levels of every grouping factor, usually necessary for identifiable variances.  As for \code{check.nlevel.gtreq.5}: \code{nobs<nlevels} will be tested for LMMs and GLMMs with estimated scale parameters; \code{nobs<=nlevels} will be tested for GLMMs with fixed scale parameter.
+##' @param ensureXrank logical - drop columns from the design matrix to ensure to ensure that it has full rank. Sometimes needed to make the model identifiable.
 ##' @param \dots additional arguments to be passed to the nonlinear optimizer (see \code{\link{Nelder_Mead}},
 ##'    \code{\link[minqa]{bobyqa}}). In particular, both \code{Nelder_Mead} and \code{bobyqa} use \code{maxfun} to specify
 ##'    the maximum number of function evaluations they will try before giving up - in contrast to \code{\link{optim}} and \code{optimx}-wrapped optimizers, which use \code{maxit}.
@@ -62,6 +63,7 @@ lmerControl <- function(optimizer="Nelder_Mead",
                         check.nlev.gtreq.5="ignore",
                         check.nlev.gtr.1="stop",
                         check.nobs.vs.nRE="stop",
+                        ensureXrank=TRUE,
                         optCtrl = list())
 {
     ## FIXME: is there a better idiom?  match.call() ?
@@ -81,7 +83,8 @@ lmerControl <- function(optimizer="Nelder_Mead",
                              check.nobs.vs.nlev,
 			     check.nlev.gtreq.5,
 			     check.nlev.gtr.1,
-                             check.nobs.vs.nRE),
+                             check.nobs.vs.nRE,
+                             ensureXrank),
                         optCtrl=optCtrl),
 	      class = c("lmerControl", "merControl"))
 }
@@ -102,6 +105,7 @@ glmerControl <- function(optimizer=c("bobyqa","Nelder_Mead"),
                          check.nlev.gtreq.5="ignore",
                          check.nlev.gtr.1="stop",
                          check.nobs.vs.nRE="stop",
+                         ensureXrank=TRUE,
                          tolPwrss = 1e-7,
                          compDev = TRUE,
                          optCtrl = list())
@@ -133,7 +137,8 @@ glmerControl <- function(optimizer=c("bobyqa","Nelder_Mead"),
                                   check.nobs.vs.nlev,
 				  check.nlev.gtreq.5,
 				  check.nlev.gtr.1,
-                                  check.nobs.vs.nRE),
+                                  check.nobs.vs.nRE,
+                                  ensureXrank),
                         optCtrl=optCtrl),
 	      class = c("glmerControl", "merControl"))
 }

--- a/man/lmerControl.Rd
+++ b/man/lmerControl.Rd
@@ -12,8 +12,9 @@ lmerControl(optimizer = "Nelder_Mead",
     check.nobs.vs.rankZ = "warningSmall",
     check.nobs.vs.nlev = "stop",
     check.nlev.gtreq.5 = "ignore",
-    check.nlev.gtr.1 = "stop", 
-    check.nobs.vs.nRE="stop", 
+    check.nlev.gtr.1 = "stop",
+    check.nobs.vs.nRE="stop",
+    ensureXrank=TRUE,
     optCtrl = list())
 
 glmerControl(optimizer = c("bobyqa", "Nelder_Mead"),
@@ -23,6 +24,7 @@ glmerControl(optimizer = c("bobyqa", "Nelder_Mead"),
     check.nlev.gtreq.5 = "ignore",
     check.nlev.gtr.1 = "stop",
     check.nobs.vs.nRE="stop",
+    ensureXrank=TRUE,
     tolPwrss = 1e-07,
     compDev = TRUE, optCtrl = list())
 
@@ -96,7 +98,10 @@ nlmerControl(optimizer = "Nelder_Mead", tolPwrss = 1e-10,
     checking whether the number of observations is greater
     than (or greater than or equal to) the number of random-effects
     levels for each term, usually necessary for identifiable variances.
-    As for \code{check.nobs.vs.nlev}.} 
+    As for \code{check.nobs.vs.nlev}.}
+  \item{ensureXrank}{logical - drop columns from the design matrix to ensure to
+    ensure that it has full rank. Sometimes needed to make the model
+    identifiable.}
   \item{optCtrl}{a \code{\link{list}} of additional arguments to be
     passed to the nonlinear optimizer (see \code{\link{Nelder_Mead}},
     \code{\link[minqa]{bobyqa}}).  In particular, both

--- a/tests/nadrop.R
+++ b/tests/nadrop.R
@@ -22,7 +22,7 @@ nNA <- sum(is.na(d$x))
 stopifnot(sum(is.na(predict(fm2)))==nNA)
 stopifnot(sum(is.na(residuals(fm2)))==nNA)
 expect_error(fm3 <- lmer(y~x+(1|f),data=d,na.action="na.pass"),
-             "infinite or missing values")
+             "Error in qr.default")
 
 refit(fm0)
 refit(fm1)


### PR DESCRIPTION
I propose adding these changes to automatically remove redundant columns from X to ensure that it has
full rank before fitting the model. It basically comes down to making a LINPACK `qr` decomposition of X and remove columns detected to be linear combinations of other columns down to a tolerance. I have left the orignal check for X rank deficiency, and I have added the control option `ensureXrank=TRUE`, so the automatic check can be disabled if you want to save the time it takes to do a QR on X. 

I increased version from 1.1-0 to 1.1-1 to able to distinguish the packages locally, but you might not want that - don't know what your policy is here. 

I have updated relevant tests and added some tests related to `anova` on single model fits which are affected. 

The main benefit of this change is the ability to fit models such as

```
set.seed(101) ## borrowed from ./inst/tests/test-rank.R
n <- 20
x <- y <- rnorm(n)
z <- rnorm(n)
r <- sample(1:5, size=n, replace=TRUE)
d <- data.frame(x,y,z,r)
d2 <- expand.grid(a=factor(1:4),b=factor(1:4),rep=1:10)
n <- nrow(d2)
d2 <- transform(d2,r=sample(1:5, size=n, replace=TRUE),
                z=rnorm(n))
d2 <- subset(d2,!(a=="4" & b=="4"))
fm <- lmer( z ~ a*b + (1|r), data=d2)
design is column rank deficient so dropping 1 coef
anova(fm)
Analysis of Variance Table
    Df Sum Sq Mean Sq F value
a    3 3.6087 1.20290  1.3046
b    3 4.4842 1.49473  1.6211
a:b  8 4.6847 0.58559  0.6351
```

As you see, [g]lmer signals that it drops 1 coefficient (and maybe you want an option to turn of that message?). The best thing would naturally be to simulate the `lm` behaviour and have the offending coefficient show up as `NA` in `print` and `summary`, but that involves much deeper changes to the code base:

```
d> fm
Linear mixed model fit by REML ['lmerMod']
Formula: z ~ a * b + (1 | r) 
   Data: d2 
REML criterion at convergence: 406.6967 
Random effects:
 Groups   Name        Std.Dev.
 r        (Intercept) 0.0000  
 Residual             0.9602  
Number of obs: 150, groups: r, 5
Fixed Effects:
(Intercept)           a2           a3           a4           b2           b3  
   -0.29790     -0.15957      0.29289     -0.08277      0.41987      0.61012  
         b4        a2:b2        a3:b2        a4:b2        a2:b3        a3:b3  
    0.20171     -0.25529     -0.15419     -0.29456     -0.48281     -0.09069  
      a4:b3        a2:b4        a3:b4  
   -0.01160      0.54335     -0.17982  
d> lm(z ~ a*b, data=d2)

Call:
lm(formula = z ~ a * b, data = d2)

Coefficients:
(Intercept)           a2           a3           a4           b2           b3  
   -0.29790     -0.15957      0.29289     -0.08277      0.41987      0.61012  
         b4        a2:b2        a3:b2        a4:b2        a2:b3        a3:b3  
    0.20171     -0.25529     -0.15419     -0.29456     -0.48281     -0.09069  
      a4:b3        a2:b4        a3:b4        a4:b4  
   -0.01160      0.54335     -0.17982           NA  
```

Here is another 'real world' example which benefits from the change:

```
d> data(soup, package="ordinal")
d> sureness <- as.numeric(as.character(soup$SURENESS))
d> fm2 <- lmer(sureness ~ PRODID * DAY + (1|RESP), data=soup)
design is column rank deficient so dropping 1 coef
d> anova(fm2)
Analysis of Variance Table
           Df Sum Sq Mean Sq F value
PRODID      5 638.06 127.611 41.3472
DAY         1  19.29  19.289  6.2497
PRODID:DAY  4  27.25   6.811  2.2070
```

so now I can get the ANOVA F-test of the interaction. 

Hope that you are positive of my proposal.
All the best,
Rune
