### PR TITLE
DOC: troubleshooting advice for error about factors with <2 levels

### DIFF
--- a/man/troubleshooting.Rd
+++ b/man/troubleshooting.Rd
@@ -17,6 +17,15 @@
     estimates has a large eigenvalue, indicating that the surface is
     nearly flat in some direction. Consider centering and/or scaling
     continuous predictor variables.
+    \item \code{Contrasts can be applied only to factors with 2 or more levels}
+    One or more of the categorical predictors in the model has fewer than two
+    levels. This may be due to user error when converting these predictors to 
+    factors prior to modeling, or it may result from some factor levels being
+    eliminated due to \code{NA}s in other predictors. Double-check the number
+    of data points in each factor level to see which one is the culprit:
+    \code{lapply(na.omit(df[,vars]), table)} (where \code{df} is the 
+    \code{data.frame} and \code{vars} are the column names of your predictor
+    variables).
   }
 }
 


### PR DESCRIPTION
Following up on @bbolker's suggestion [here](https://stat.ethz.ch/pipermail/r-sig-mixed-models/2014q3/022596.html) to add the `Contrasts can be applied only to factors with 2 or more levels` error to the troubleshooting docs.
