### PR TITLE
Remove {r} from lmerperf vignette

### DIFF
--- a/vignettes/lmerperf.Rmd
+++ b/vignettes/lmerperf.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
   consuming derivative calculation that is performed after the optmization
   is finished. e.g.
 
-```{r}
+```
 lmer(y ~ service * dept + (1|s) + (1|d), InstEval,
   control = lmerControl(calc.derivs = FALSE))
 ```
@@ -32,7 +32,7 @@ lmer(y ~ service * dept + (1|s) + (1|d), InstEval,
   turned off like this (here we have specified the `"nlminb"` method but this 
   applies to any optimx method):
 
-```{r}
+```
 lmer(y ~ service * dept + (1|s) + (1|d), InstEval,
   control = lmerControl(optimizer = "optimx", calc.derivs = FALSE,
     optCtrl = list(method = "nlminb", starttests = FALSE, kkt = FALSE)))
@@ -50,7 +50,7 @@ lmer(y ~ service * dept + (1|s) + (1|d), InstEval,
   increase `maxeval` if the optimization requires more than 1000 iterations
   and you wish to allow it to proceed.)
 
-```{r}
+```
 nlopt <- function(par, fn, lower, upper, control) {
     .nloptr <<- res <- nloptr(par, fn, lb = lower, ub = upper, 
         opts = list(algorithm = "NLOPT_LN_BOBYQA", print_level = 1,

--- a/vignettes/lmerperf.Rmd
+++ b/vignettes/lmerperf.Rmd
@@ -68,5 +68,5 @@ nlopt <- function(par, fn, lower, upper, control) {
     )
 }
 lmer(y ~ service * dept + (1|s) + (1|d), InstEval,
-    control = lmerControl(optimizer = "nloptwrap", calc.derivs = FALSE))
+    control = lmerControl(optimizer = "nlopt", calc.derivs = FALSE))
 ```


### PR DESCRIPTION
Removed `{r}` occurrences from lmerperf vignette to avoid having it attempt to parse the chunks.
