### PR TITLE
add control for constant response checking

### DIFF
--- a/R/lmerControl.R
+++ b/R/lmerControl.R
@@ -160,6 +160,7 @@ glmerControl <-
 	     "stop.deficient", "ignore"),
 	     check.scaleX = "warning",
 	     check.formula.LHS="stop",
+	     check.response.not.const = "stop",
 	     ## convergence checking options
 	     check.conv.grad	 = .makeCC("warning", tol = 1e-3, relTol = NULL),
 	     check.conv.singular = .makeCC(action = "ignore",  tol = 1e-4),
@@ -218,7 +219,8 @@ glmerControl <-
                                   check.nobs.vs.nRE,
 				  check.rankX,
                                   check.scaleX,
-                                  check.formula.LHS),
+                                  check.formula.LHS,
+				                          check.response.not.const),
                         checkConv=
                         namedList(check.conv.grad,
                                   check.conv.singular,

--- a/R/modular.R
+++ b/R/modular.R
@@ -277,6 +277,20 @@ chkRank.drop.cols <- function(X, kind, tol = 1e-7, method = "qr.R") {
     X
 }
 
+# check that response is not constant
+checkResponse <- function(y, ctrl) {
+  stopifnot(is.list(ctrl))
+  cstr <- "check.response.not.const"
+  checkCtrlLevels(cstr, cc <- ctrl[[cstr]])
+  if (doCheck(cc) && length(unique(y)) < 2L) {
+    wstr <- "Response is constant"
+    switch(cc,
+           "warning" = warning(wstr, call.=FALSE),
+           "stop"   =    stop(wstr, call.=FALSE),
+           stop(gettextf("unknown check level for '%s'", cstr), domain=NA))
+  } else character()
+}
+
 ##' Extract all warning msgs from a merMod object
 .merMod.msgs <- function(x) {
     ## currently only those found with 'X' :
@@ -669,8 +683,7 @@ mkGlmerDevfun <- function(fr, X, reTrms, family, nAGQ = 1L, verbose = 0L,
     if(control$nAGQ0initStep) nAGQinit <- 0L else nAGQinit <- 1L
     ## allow trivial y
     if (length(y <- rho$resp$y) > 0) {
-        if (length(unique(y)) < 2L)
-            stop("Response is constant - cannot fit the model")
+        checkResponse(y, control$checkControl)
         rho$verbose     <- as.integer(verbose)
 
         ## initialize (from mustart)

--- a/man/lmerControl.Rd
+++ b/man/lmerControl.Rd
@@ -63,6 +63,7 @@ glmerControl(optimizer = c("bobyqa", "Nelder_Mead"),
                     "stop.deficient", "ignore"),
     check.scaleX  = "warning",
     check.formula.LHS = "stop",
+    check.response.not.const = "stop",
     ## convergence checking options
     check.conv.grad     = .makeCC("warning", tol = 1e-3, relTol = NULL),
     check.conv.singular = .makeCC(action = "ignore",  tol = 1e-4),
@@ -193,6 +194,8 @@ nlmerControl(optimizer = "Nelder_Mead", tolPwrss = 1e-10,
     \code{simulate.merMod};
     \emph{use at your own risk} as it may allow the generation
     of unstable \code{merMod} objects}
+  \item{check.response.not.const}{character - check that the
+    response is not constant.}
 
   \item{optCtrl}{a \code{\link{list}} of additional arguments to be
     passed to the nonlinear optimizer (see \code{\link{Nelder_Mead}},


### PR DESCRIPTION
I want to be able to turn off checking that the response is constant, previously done in mkGlmerDevfun. So I've added an option "check.response.not.const" to glmerControl to allow the user to ignore that check. 

I haven't yet added the option to lmerControl, because no checking for constant response is currently done in mkLmerDevfun, but I could change this?