### PR TITLE
Add CRAN version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ lme4: Mixed-effects models in R.
 
 [![Build Status](https://travis-ci.org/lme4/lme4.svg?branch=master)](https://travis-ci.org/lme4/lme4)
 [![downloads](http://cranlogs.r-pkg.org/badges/lme4)](http://cranlogs.r-pkg.org/badges/lme4)
+[![cran version](http://www.r-pkg.org/badges/version/lme4)](http://cran.rstudio.com/web/packages/lme4)
 
 ## Recent/release notes
 


### PR DESCRIPTION
Versions can make a big difference with lme4!

Added a little badge so users can see which version is on CRAN with a glance.