### PR TITLE
Reset offsets after stage 2 boundary check

### DIFF
--- a/R/modular.R
+++ b/R/modular.R
@@ -771,10 +771,13 @@ optimizeGlmer <- function(devfun,
     }
     if (restart_edge) ## FIXME: implement this ...
         stop("restart_edge not implemented for optimizeGlmer yet")
-    if (boundary.tol > 0)
-        check.boundary(rho, opt, devfun, boundary.tol)
-    else
-        opt
+
+    if (boundary.tol > 0) {
+        opt <- check.boundary(rho, opt, devfun, boundary.tol)
+        if(stage != 1) rho$resp$setOffset(rho$baseOffset)
+    }
+
+    return(opt)
 }
 
 check.boundary <- function(rho,opt,devfun,boundary.tol) {


### PR DESCRIPTION
I think this might fix https://github.com/lme4/lme4/issues/319.

I'm not 100% sure what's going on with `offset`, `baseOffset`, and needing to replace one with the other after you call `devfun`. But it looks like not doing this after `optimizeGlmer` calls `check.boundary` is what's been causing the numerical errors in `glmer.nb`.

Anyway, it's passing Travis on my fork, but someone should double check to see if this fix actually makes sense.