### PR TITLE
Fix typo in man/modular.Rd

### DIFF
--- a/man/modular.Rd
+++ b/man/modular.Rd
@@ -40,7 +40,7 @@ updateGlmerDevfun(devfun, reTrms, nAGQ = 1L)
 }
 \arguments{
   \item{formula}{a two-sided linear formula object
-    describing both the fixed-effects and fixed-effects part
+    describing both the fixed-effects and random-effects parts
     of the model, with the response on the left of a \code{~}
     operator and the terms, separated by \code{+} operators,
     on the right.  Random-effects terms are distinguished by


### PR DESCRIPTION
Hi, I have made a very small change to fix what I think is a typo in the 'Modular Functions for Mixed Model Fits' documentation:

Original: 'both the fixed-effects and fixed-effects part'
Fix: 'both the fixed-effects and random-effects parts'