### PR TITLE
added provision for refit to deal with 'optimx'

### DIFF
--- a/R/lmer.R
+++ b/R/lmer.R
@@ -1265,7 +1265,9 @@ refit.merMod <- function(object,
 	    glmerControl()
 	else
 	    lmerControl()
-
+  if (object@optinfo$optimizer == "optimx") {
+   control$optCtrl <- object@optinfo$control
+  }
     ## we need this stuff defined before we call .glmerLaplace below ...
     pp      <- object@pp$copy()
     dc      <- object@devcomp


### PR DESCRIPTION
In the current version `refit` fails if optimizer is one of `optimx`:

```
require(lme4)
require(optimx)

## taken from ?refit
sleepstudyNA <- sleepstudy
sleepstudyNA$Reaction[1:3] <- NA
fm0b <- lmer(Reaction ~ Days + (1|Subject), sleepstudyNA, 
             control =lmerControl(optimizer = "optimx",optCtrl = list(method ="nlminb")))
ss0b <- refit(fm0b, simulate(fm0b))
# Error in optwrap(object@optinfo$optimizer, ff, x0, lower = lower, control = control$optCtrl,  : 
#   must specify 'method' explicitly for optimx
```

This pull request adds a small patch that, in case `optimx` is the optimizer, automatically uses the `control` settings of the existing fit object which contains the information necessary (i.e., the `method` slot).
```
fm0b <- lmer(Reaction ~ Days + (1|Subject), sleepstudyNA, 
             control =lmerControl(optimizer = "optimx",optCtrl = list(method ="nlminb")))
(ss0b <- refit(fm0b, simulate(fm0b)))
# Linear mixed model fit by REML ['lmerMod']
# Formula: Reaction ~ Days + (1 | Subject)
#    Data: sleepstudyNA
# REML criterion at convergence: 1774.794
# Random effects:
#  Groups   Name        Std.Dev.
#  Subject  (Intercept) 39.82   
#  Residual             31.66   
# Number of obs: 177, groups:  Subject, 18
# Fixed Effects:
# (Intercept)         Days  
#     248.703        9.566  
```  

I also tried a solution using a more general approach (i.e., always reusing the existing `method` slot), but with this I could not run `R CMD check` without warnings. With the proposed change, `R CMD check` runs without any issues.
