### PR TITLE
add expand_re to lmer

### DIFF
--- a/R/lmer.R
+++ b/R/lmer.R
@@ -2,7 +2,7 @@
 ## FIXME: need to document S3 methods better (can we pull from r-forge version?)
 
 ##' Fit a linear mixed model (LMM)
-lmer <- function(formula, data=NULL, REML = TRUE,
+lmer <- function(formula, data=NULL, REML = TRUE, expand_re = FALSE,
                  control = lmerControl(), start = NULL,
                  verbose = 0L, subset, weights, na.action, offset,
                  contrasts = NULL, devFunOnly=FALSE,

--- a/R/modular.R
+++ b/R/modular.R
@@ -321,7 +321,7 @@ checkResponse <- function(y, ctrl) {
 ##' \item{REML}{(lFormula only): logical flag: use restricted maximum likelihood? (Copy of argument.)}
 ##' @importFrom Matrix rankMatrix
 ##' @export
-lFormula <- function(formula, data=NULL, REML = TRUE,
+lFormula <- function(formula, data=NULL, REML = TRUE, expand_re = FALSE,
                      subset, weights, na.action, offset, contrasts = NULL,
                      control=lmerControl(), ...)
 {
@@ -345,10 +345,20 @@ lFormula <- function(formula, data=NULL, REML = TRUE,
                              checkLHS = control$check.formula.LHS == "stop")
     #mc$formula <- formula <- as.formula(formula,env=denv) ## substitute evaluated call
     formula <- as.formula(formula, env=denv)
-    ## as.formula ONLY sets environment if not already explicitly set ...
-    ## ?? environment(formula) <- denv
-    # get rid of || terms so update() works as expected
-    RHSForm(formula) <- expandDoubleVerts(RHSForm(formula))
+    
+    if (expand_re) {
+      expand_re_out <- expand_re_fun(formula = formula, data = data)
+      formula <- as.formula(expand_re_out$formula)
+      assign(as.character(mf[["data"]]), 
+             cbind(get(as.character(mf[["data"]]), parent.frame()), 
+                   expand_re_out$new_col), parent.frame())
+    } else {
+      ## as.formula ONLY sets environment if not already explicitly set ...
+      ## ?? environment(formula) <- denv
+      # get rid of || terms so update() works as expected
+      RHSForm(formula) <- expandDoubleVerts(RHSForm(formula))
+    }
+    
     mc$formula <- formula
 
     ## (DRY! copied from glFormula)


### PR DESCRIPTION
This is the first suggestion to add the functionality of `afex`'s `expand_re` to `lme4`. This is only the bare bone implementation (i.e., missing documentation and tests) intended to serve as basis for further discussion. This pull request is a response of Ben Bolker's [call for a pull request](https://stats.stackexchange.com/a/326076/442). I am happy to add the missing pieces as well as `glmer` support after agreement on what is it that is missing.

The basic idea is to add an `expand_re` argument in the same manner as in `afex` to `lmer` directly and then pass it on to `lFormula` where the functionality is invoked if `TRUE`.

I have changed the original [`expand_re_fun`](https://github.com/singmann/afex/blob/master/R/mixed.R#L692) slightly. I have removed the dependencies to `stringr`, and changed arguments and return value. However, the functionality is exactly the same. It transforms a model matrix with `||` into a numerical model matrix via `model.matrix` and then sets up a new random effects formula with `(0 + col|...)` for each column in the model matrix. Thus, it allows the estimation of uncorrelated random slopes for categorical covariates.

The main conceptual problem I had to solve was how to deal with the changes in the `data.frame` used for fitting (i.e., the additional columns). The main hurdle appeared to be the calls to `eval` which require the columns to be part of the data. Especially `fr <- eval(mf, parent.frame())` (now line 380 in `modular.r`) seemed to fail consistently (and understandably). Even when trying to add the additional columns to the environment of the formula (as suggested by the comments in the code).

The solution I have used now works, but does not follow a strict functional paradigm. I simply add the columns to the existing `data.frame` in the `parent.frame()` (i.e., the global environment if called from there)!  One obvious downside (besides changing the users data) is that this adds the columns multiple times when called multiple times (this can probably be caught).
However, I have no idea for how to implement this differently without changing the existing `eval` calls (which seems rather risky).

Here an example of the current functionality:
```
data("Machines", package = "MEMSS") 
Machines$XX <- 11 ## just added so data has a column that is irrelevant
str(Machines)
# 'data.frame':	54 obs. of  4 variables:
#  $ Worker : Factor w/ 6 levels "1","2","3","4",..: 1 1 1 2 2 2 3 3 3 4 ...
#  $ Machine: Factor w/ 3 levels "A","B","C": 1 1 1 1 1 1 1 1 1 1 ...
#  $ score  : num  52 52.8 53.1 51.8 52.8 53.1 60 60.2 58.4 51.1 ...
#  $ XX     : num  11 11 11 11 11 11 11 11 11 11 ...

# simple model with random-slopes for repeated-measures factor
m1 <- lmer(score ~ Machine + (Machine|Worker), data=Machines)
summary(m1)$varcor
 # Groups   Name        Std.Dev. Corr         
 # Worker   (Intercept) 4.07928               
 #          MachineB    5.87764   0.484       
 #          MachineC    3.68985  -0.365  0.297
 # Residual             0.96158 

# suppress correlation among random effect parameters with expand_re = TRUE
m2 <- lmer(score ~ Machine + (Machine||Worker), data=Machines, expand_re = TRUE)
summary(m2)$varcor
 # Groups   Name         Std.Dev.
 # Worker   (Intercept)  4.07425 
 # Worker.1 re1.MachineB 5.88935 
 # Worker.2 re1.MachineC 3.64708 
 # Residual              0.96228 
str(Machines)
# 'data.frame':	54 obs. of  6 variables:
#  $ Worker      : Factor w/ 6 levels "1","2","3","4",..: 1 1 1 2 2 2 3 3 3 4 ...
#  $ Machine     : Factor w/ 3 levels "A","B","C": 1 1 1 1 1 1 1 1 1 1 ...
#  $ score       : num  52 52.8 53.1 51.8 52.8 53.1 60 60.2 58.4 51.1 ...
#  $ XX          : num  11 11 11 11 11 11 11 11 11 11 ...
#  $ re1.MachineB: num  0 0 0 0 0 0 0 0 0 0 ...
#  $ re1.MachineC: num  0 0 0 0 0 0 0 0 0 0 ...
```

If there is agreement that changing the data is acceptable, I am happy to add some heuristics to not add the same columns multiple times.
