### PR TITLE
models with very large numbers of random effects can cause predict to run out of memory

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -252,7 +252,7 @@ mkNewReTrms <- function(object, newdata, re.form=NULL, na.action=na.pass,
         if (!allow.new.levels && any(vapply(ReTrms$flist, anyNA, NA)))
             stop("NAs are not allowed in prediction data",
                  " for grouping variables unless allow.new.levels is TRUE")
-        ns.re <- names(re <- ranef(object))
+        ns.re <- names(re <- ranef(object, condVar = FALSE))
         nRnms <- names(Rcnms <- ReTrms$cnms)
         if (!all(nRnms %in% ns.re))
             stop("grouping factors specified in re.form that were not present in original model")


### PR DESCRIPTION
Minor change to make predict faster and avoid out of memory errors when very large numbers of random effects are in the model.

I ran into out of memory issues dealing with random intercept model where the grouping factor had hundreds of thousands of levels.

The variance structure from ranef does not appear to be used here.