### PR TITLE
Don't compute random effect covariance where unused

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Authors@R: c(
     person("Gabor", "Grothendieck", role="ctb"),
     person("Peter", "Green", role="ctb",
 	comment=c(ORCID="0000-0002-0238-9852")),
-    person("John", "Fox", role="ctb")
+    person("John", "Fox", role="ctb"),
+    person("Alexander", "Bauer", role="ctb")
     )
 Contact: LME4 Authors <lme4-authors@lists.r-forge.r-project.org>
 Description: Fit linear and generalized linear mixed-effects models.

--- a/R/lmer.R
+++ b/R/lmer.R
@@ -638,7 +638,7 @@ coefMer <- function(object, ...)
         warning('arguments named "', paste(names(list(...)), collapse = ", "),
                 '" ignored')
     fef <- data.frame(rbind(fixef(object)), check.names = FALSE)
-    ref <- ranef(object)
+    ref <- ranef(object, condVar = FALSE)
     ## check for variables in RE but missing from FE, fill in zeros in FE accordingly
     refnames <- unlist(lapply(ref,colnames))
     nmiss <- length(missnames <- setdiff(refnames,names(fef)))


### PR DESCRIPTION
`condVar` quickly becomes rather huge and expensive to create for models with complicated random effects, so we should not compute it unless it's actually used. It isn't used in `coef.merMod`, so let's not compute it.

All credit due to @bauer-alex who suggested this change and who also created this example: 
``` r
library(gamm4)

# data simulation ---------------------------------------------------------
# simulate data for 2000 persons with 20 measurements each

set.seed(0)
N <- 2000
n_i <- 20
dat <- mgcv::gamSim(1, n=N * n_i, scale=1)
# add a factor person id
dat$z <- factor(rep(1:N, each = n_i))


# model estimation --------------------------------------------------------
# estimate a Gaussian model on response y with a smooth effect of f
# and random slopes of x0, x1, x2, and x3 based on the factor z
# -> estimation of 2000 * 4 = 8000 random slopes
random.formula <- formula("~ (0 + x0 + x1 + x2 + x3 || z)")

m <- gamm4::gamm4(y ~ s(f), random = random.formula,
                  data = dat)

object.size(ranef(m$mer))
# 260864 bytes
object.size(ranef(m$mer, condVar = FALSE))
#194960 bytes

# current version:
system.time(coef(m$mer))
#  user  system elapsed 
# 3.077   0.029   3.103 

# switch to proposed coef-version:
# devtools::load_all(".")
system.time(coef(m$mer))
#  user  system elapsed 
# 0.003   0.011   0.015 
```