### PR TITLE
Fix data validation in corner cases

### DIFF
--- a/R/lmer.R
+++ b/R/lmer.R
@@ -564,7 +564,7 @@ anovaLmer <- function(object, ..., refit = TRUE, model.names=NULL) {
                           deviance = -2*llk,
                           Chisq = chisq,
                           Df = dfChisq,
-                          "Pr(>Chisq)" = pchisq(chisq, dfChisq, lower.tail = FALSE),
+                          "Pr(>Chisq)" = ifelse(dfChisq==0,NA,pchisq(chisq, dfChisq, lower.tail = FALSE)),
                           row.names = names(mods), check.names = FALSE)
         class(val) <- c("anova", class(val))
         forms <- lapply(lapply(calls, `[[`, "formula"), deparse)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -895,41 +895,13 @@ checkArgs <- function(type,...) {
 ## if #3 is true *and* the user is doing something tricky with nested functions,
 ## this may fail ...
 
-## from http://stackoverflow.com/questions/14945274/determine-whether-evaluation-of-an-argument-will-fail-due-to-non-existence
-missDataFun <- function(d) {
-    ## test here
-    ff <- sys.frames()
-    ex <- substitute(d)
-    ii <- rev(seq_along(ff))
-    foundAnon <- FALSE
-    for(i in ii) {
-        ## trying to find where the original symbol is defined ...
-        ex <- eval(substitute(substitute(x, env=sys.frames()[[n]]),
-                              env = list(x = ex, n=i)))
-        if (is.symbol(ex) && grepl("^\\.\\.[0-9]+$",safeDeparse(ex))) {
-            ## testing for the dreaded "..1", "..2" pattern; this means
-            ## we are stuck in an anonymous function somewhere ...
-            ## won't be able to see whether data exist or not,
-            ## but we should not flag them as missing -- definitely
-            ## causes false positives
-            ## might be better to check against quote(..1), quote(..2),
-            ## ... but ugh ...
-            foundAnon <- TRUE
-            break
-        }
-    }
-    return(!foundAnon && is.symbol(ex) && !exists(deparse(ex)))
-}
-
 ## try to diagnose missing/bad data
 checkFormulaData <- function(formula, data, checkLHS=TRUE,
                              checkData=TRUE, debug=FALSE) {
-    nonexist.data <- missDataFun(data)
-    wd <- tryCatch(eval(data), error = identity)
-    if (wrong.data <- inherits(wd,"simpleError")) {
-        wrong.data.msg <- wd$message
+    wd <- tryCatch(force(data), error = identity)
+    if (bad.data <- inherits(wd,"simpleError")) {
+        bad.data.msg <- wd$message
     }
-    bad.data <- nonexist.data || wrong.data
 
     ## data not found (this *should* only happen with garbage input,
     ## OR when strings used as formulae -> drop1/update/etc.)
@@ -945,11 +917,7 @@ checkFormulaData <- function(formula, data, checkLHS=TRUE,
                  "try specifying 'formula' as a formula rather ",
                  "than a string in the original model",call.=FALSE)
         } else {
-            if (nonexist.data) {
-                stop("'data' not found, and some variables missing from formula environment",call.=FALSE)
-            } else {
-                stop("bad 'data': ",wrong.data.msg)
-            }
+            stop("bad 'data': ", bad.data.msg, call. = FALSE)
         }
     } else {
         denv <- ## The data as environment

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -899,7 +899,7 @@ checkArgs <- function(type,...) {
 checkFormulaData <- function(formula, data, checkLHS=TRUE,
                              checkData=TRUE, debug=FALSE) {
     wd <- tryCatch(force(data), error = identity)
-    if (bad.data <- inherits(wd,"simpleError")) {
+    if (bad.data <- inherits(wd,"error")) {
         bad.data.msg <- wd$message
     }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -4,7 +4,18 @@
 \title{lme4 News}
 \encoding{UTF-8}
 
-\section{CHANGES IN VERSION 1.1-23 (2020-03-06}{
+\section{CHANGES IN VERSION 1.1-23.9000 (unreleased)}{
+  \subsection{USER-VISIBLE CHANGES}{
+    \itemize{
+      \item \code{anova()} now returns a p-value of \code{NA} if the df
+      difference between two models is 0 (implying they are equivalent
+      models) (GH#583, @MetaEntropy)
+      \item speedup in \code{coef()} for large models, by skipping
+      conditional variance calculation (Alexander Bauer)
+    }
+  }
+}
+\section{CHANGES IN VERSION 1.1-23 (2020-03-06)}{
   This is primarily for CRAN compliance (previous submission was
   retracted to allow time for downstream package adjustments).
   \itemize{

--- a/src/external.cpp
+++ b/src/external.cpp
@@ -304,7 +304,7 @@ extern "C" {
                             double tol, int maxit, int verbose) {
         double oldpdev=std::numeric_limits<double>::max();
         double pdev;
-        int maxstephalfit = 10;
+        int maxstephalfit = 20;
         bool   cvgd = false, verb = verbose > 2, moreverb = verbose > 10;
         int debug=0;
 

--- a/tests/testthat/test-formulaEval.R
+++ b/tests/testthat/test-formulaEval.R
@@ -27,16 +27,18 @@ test_that("glmerFormX", {
     ## WARNING: these drop/environment tests are extremely sensitive to environment
     ## they may fail/not fail, or fail differently, within a "testthat" environment vs.
     ##   when run interactively
-    ## AICvec <- c(77.0516381151634, 75.0819116367084, 75.1915023640827)
     expect_that(m_data.3 <- glmer( modStr , data=d, family="binomial"), is_a("glmerMod"))
     expect_that(m_data.4 <- glmer( "x ~ y + z + (1|r)" , data=d, family="binomial"), is_a("glmerMod"))
-    ## interactively:
+    ## interactively: (interactive() is TRUE {i.e. doesn't behave as I would expect} within testing environment ...
+    ## if (interactive()) {
+    ## AICvec <- c(77.0516381151634, 75.0819116367084, 75.1915023640827)
     ## expect_equal(drop1(m_data.3)$AIC,AICvec)
     ## expect_equal(drop1(m_data.4)$AIC,AICvec)
-    ## in test environment:
-    expect_error(drop1(m_data.3),data_RE)
-    expect_error(drop1(m_data.4),data_RE)
-
+    ## } else {
+        ## in test environment [NOT test_
+        expect_error(drop1(m_data.3),data_RE)
+        expect_error(drop1(m_data.4),data_RE)
+    ##}
 })
 
 test_that("glmerForm", {

--- a/tests/testthat/test-lmer.R
+++ b/tests/testthat/test-lmer.R
@@ -19,7 +19,7 @@ test_that("lmer", {
     ## expect_warning(lmer(z~ 1|f, d, method="Laplace"),"Use the REML argument")
     ##sp No '...' anymore
     ##sp expect_warning(lmer(z~ 1|f, d, sparseX=TRUE),"has no effect at present")
-    expect_error(lmer(z~ 1|f, ddd), "'data' not found")
+    expect_error(lmer(z~ 1|f, ddd), "bad 'data': object 'ddd' not found")
     expect_error(lmer(z~ 1|f), "object 'z' not found")
     expect_error(lmer(z~ 1|f, d[,1:1000]), "bad 'data': undefined columns selected")
     expect_is(fm1 <- lmer(Yield ~ 1|Batch, Dyestuff), "lmerMod")

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -148,6 +148,8 @@ test_that("lmer", {
     expect_equal(aa2[2,"Chisq"],0)
 
     expect_warning(anova(fm1,type="III"),"additional arguments ignored")
+
+    aa <- suppressMessages(anova(fm0,fm0))
 })
 
 context("bootMer confint()")

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -149,7 +149,10 @@ test_that("lmer", {
 
     expect_warning(anova(fm1,type="III"),"additional arguments ignored")
 
-    aa <- suppressMessages(anova(fm0,fm0))
+    ## set p-values to NA for equivalent models: #583
+    fm0B <- fm0
+    aa <- suppressMessages(anova(fm0B,fm0))
+    expect_true(all(is.na(aa[["Pr(>Chisq)"]])))
 })
 
 context("bootMer confint()")


### PR DESCRIPTION
Hello,

I'm working on a new release of magrittr with a C implementation and I found an issue in our revdepchecks that boils down to this:

```r
library(magrittr)

# Works fine
mtcars %>% lme4::lmer("disp ~ (1 | cyl)", data = .) %>% class()
#> [1] "lmerMod"
#> attr(,"package")
#> [1] "lme4"

# Fails with a wrapper
fn <- function(data) {
  lme4::lmer("disp ~ (1 | cyl)", data = data)
}
mtcars %>% fn()
#> Error in exists(v, envir = env, inherits = FALSE) :
#>   use of NULL environment is defunct
```

A pure base R reprex can be constructed with `do.call()` (a wrapper for the C-level `Rf_eval()` function) and an artificial environment that doesn't appear in the inspectable frames:

```r
e <- new.env()
e$. <- mtcars

# Works
class(do.call(lme4::lmer, list("disp ~ (1 | cyl)", quote(.)), envir = e))
#> [1] "lmerMod"
#> attr(,"package")
#> [1] "lme4"

# Fails with a wrapper
fn <- function(data) {
  lme4::lmer("disp ~ (1 | cyl)", data = data)
}
do.call(fn, list(quote(.)), envir = e)
#> Error in exists(v, envir = env, inherits = FALSE) :
#>   use of NULL environment is defunct
```

This error comes from `missDataFun()` erroneously inferring that the data is missing and can't be evaluated. Looking at its implementation, it seems a bit brittle. This helper has caused other issues in the past:

- Wrong inference within `lapply()` (#369), which is the same problem.
- Performance issue with large data frames (#410).

Unless I'm missing something, the only purpose for this function is to slightly improve error messages when the data doesn't exist. Perhaps if it isn't worth the trouble? This PR is a suggested fix to solve the problem with magrittr, `do.call()`, and probably other corner cases. Here is the impact on error messages:

```r
# Before
lme4::lmer(z ~ 1|f, ddd)
#> Error: 'data' not found, and some variables missing from formula environment

# After
lme4::lmer(z ~ 1|f, ddd)
#> Error: bad 'data': object 'ddd' not found
```