### PR TITLE
reserve C++ vector in allPerm_int

### DIFF
--- a/R/sparsegrid.R
+++ b/R/sparsegrid.R
@@ -6,8 +6,16 @@ GQdk <- function(d=1L, k=1L) {
               0L < (k <- as.integer(k)[1]),
 	      k <= length(GQNd <- GQN[[d]]))## -> GQN, stored in ./sysdata.rda
     tmat <- t(GQNd[[k]])
-    rperms<- combinat::permn(seq_len(d) + 1L, function(v) c(1L,v))
+    ##rperms<- combinat::permn(seq_len(d) + 1L, function(v) c(1L,v))
     ## rperms <- lapply(.Call(allPerm_int, seq_len(d) + 1L), function(v) c(1L, v))
+    perms <- tryCatch (
+                       .Call(allPerm_int, seq_len(d) + 1L, as.integer(factorial(d))),
+                       warning = function (w) w,
+                       error = function (e) e)
+    if (methods::is(perms, "error") | methods::is(perms, "warning"))
+        stop("Can not allocate a vector that large")
+    rperms <- lapply(perms, function(v) c(1L, v))
+
     dd <- unname(as.matrix(do.call(expand.grid, c(rep.int(list(c(-1,1)), d), KEEP.OUT.ATTRS=FALSE))))
     unname(unique(t(do.call(cbind,
                             lapply(as.data.frame(t(cbind(1, dd))),

--- a/src/external.cpp
+++ b/src/external.cpp
@@ -51,11 +51,13 @@ extern "C" {
 
     // FIXME: as pointed out here <https://github.com/lme4/lme4/issues/588>, this is potentially
     //   dangerous when v_ is long ...
-    SEXP allPerm_int(SEXP v_) {
+    SEXP allPerm_int(SEXP v_, SEXP sz_) {
         BEGIN_RCPP;
         iVec     v(as<iVec>(v_));   // forces a copy
         int     sz(v.size());
         std::vector<iVec> vec;
+
+        vec.reserve(static_cast<size_t>(INTEGER(sz_)[0]));
 
         std::sort(v.data(), v.data() + sz);
         do {
@@ -1015,7 +1017,7 @@ static R_CallMethodDef CallEntries[] = {
 
     CALLDEF(Eigen_SSE, 0),
 
-    CALLDEF(allPerm_int, 1),
+    CALLDEF(allPerm_int, 2),
 
     CALLDEF(deepcopy, 1),
 


### PR DESCRIPTION
This is all that's needed to render the C++ code safe for #588, and you avoid extra `combinat` dependency introduced in [this commit](https://github.com/lme4/lme4/commit/f426fa2bb3dfe0b48e7e0bbc8c4633ff795301f9)