### PR TITLE
rewrite last lapply for GQdk

### DIFF
--- a/R/sparsegrid.R
+++ b/R/sparsegrid.R
@@ -17,7 +17,13 @@ GQdk <- function(d=1L, k=1L) {
     rperms <- lapply(perms, function(v) c(1L, v))
 
     dd <- unname(as.matrix(do.call(expand.grid, c(rep.int(list(c(-1,1)), d), KEEP.OUT.ATTRS=FALSE))))
-    unname(unique(t(do.call(cbind,
-                            lapply(as.data.frame(t(cbind(1, dd))),
-                                   "*", e2=do.call(cbind, lapply(rperms, function(ind) tmat[ind,])))))))
+    #unname(unique(t(do.call(cbind,
+    #                        lapply(as.data.frame(t(cbind(1, dd))),
+    #                               "*", e2=do.call(cbind, lapply(rperms, function(ind) tmat[ind,])))))))
+    e2 <- do.call(cbind, lapply(rperms, function(ind) tmat[ind,]))
+    ddf <- as.data.frame(t(cbind(1,dd)))
+    res <- NULL
+    for (i in 1:ncol(ddf))
+        res <- unique(rbind(res, t(ddf[, i] * e2)))
+    return(res)
 }


### PR DESCRIPTION
The current last line of [`GQdk`](https://github.com/lme4/lme4/blob/master/R/sparsegrid.R#L20-L22):

https://github.com/lme4/lme4/blob/38edc87c3aa880cc9de08cae3f0398b6e90cf030/R/sparsegrid.R#L20-L22

is more dangerous than it needs to be, because it constructs a potentially enormous matrix before finally applying `unique` to condense down to the desired result. The PR implements a safer version, by applying `unique` to every iteration so that the size of the matrix never gets too out of hand. The `reprex` below also illustrates that the PR code is more efficient for larger calculations:

``` r
library(lme4)
compare_methods <- function (d = 6L, k = 4L, n = 2) {
    GQNd <- GQN[[d]]
    tmat <- t(GQNd[[k]])
    perms <- .Call(allPerm_int, seq_len(d) + 1L, as.integer(factorial(d))) # okay here
    rperms <- lapply(perms, function(v) c(1L, v))
    dd <- unname(as.matrix(do.call(expand.grid, c(rep.int(list(c(-1,1)), d), KEEP.OUT.ATTRS=FALSE))))

    fn0 <- function (dd, tmat, rperms) {
        unname(unique(t(do.call(cbind,
                                lapply(as.data.frame(t(cbind(1, dd))),
                                       "*", e2=do.call(cbind, lapply(rperms, function(ind) tmat[ind,])))))))
    }
    t0 <- vapply (seq (n), function (i) {
                  ret <- system.time (res0 <- fn0 (dd, tmat, rperms)) [3]
                  assign ("res0", res0, envir = .GlobalEnv)
                  return (ret)}, numeric (1))

    fn1 <- function (dd, tmat, nperms) {
        e2=do.call(cbind, lapply(rperms, function(ind) tmat[ind,]))
        ddf <- as.data.frame(t(cbind(1,dd)))

        res <- NULL
        for (i in 1:ncol (ddf)) {
            res <- unique (rbind (res, t (ddf [, i] * e2)))
        }
        return (res)
    }
    t1 <- vapply (seq (n), function (i) {
                  ret <- system.time (res1 <- fn1 (dd, tmat, rperms)) [3]
                  assign ("res1", res1, envir = .GlobalEnv)
                  return (ret)}, numeric (1))

    if (!identical (res0, res1))
        stop ("results are not identical")

    c (orig = mean (t0), new = mean (t1))
}
d <- 2:7
do.call (rbind, lapply (d, function (i) compare_methods (d = i)))
#>         orig    new
#> [1,]  0.0000 0.0005
#> [2,]  0.0015 0.0025
#> [3,]  0.0070 0.0120
#> [4,]  0.0630 0.0735
#> [5,]  0.9965 0.6620
#> [6,] 17.3365 9.2775
```

<sup>Created on 2020-09-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>