### PR TITLE
Switch PI to M_PI to support STRICT_R_HEADERS

### DIFF
--- a/src/external.cpp
+++ b/src/external.cpp
@@ -405,7 +405,7 @@ extern "C" {
         return ans;
     }
 
-    static double sqrt2pi = std::sqrt(2. * PI);
+    static double sqrt2pi = std::sqrt(2. * M_PI);
 
     // tol: tolerance for pirls
     // maxit: maximum number of pirls iterations

--- a/src/respModule.cpp
+++ b/src/respModule.cpp
@@ -199,7 +199,7 @@ namespace lme4 {
     }
 
     double nlsResp::Laplace(double ldL2, double ldRX2, double sqrL) const {
-        double lnum = 2.* PI * (d_wrss + sqrL), n = d_y.size();
+        double lnum = 2.* M_PI * (d_wrss + sqrL), n = d_y.size();
         return ldL2 + n * (1 + std::log(lnum / n));
     }
 


### PR DESCRIPTION
Dear Ben, dear lme4 team,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history.

Your package uses (once each in two files) PI (instead of the standard C define M_PI) and PI goes away when we set STRICT_R_HEADERS (as a #define in a header or source file, a -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do). We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

This very simple PR changes PI to M_PI. Your code will then work with and without STRICT_R_HEADERS (as M_PI is an old define from C). PI only works when STRICT_R_HEADERS is not defined.

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.