### PR TITLE
don't test optimx package version if not installed

### DIFF
--- a/tests/testthat/test-lmer.R
+++ b/tests/testthat/test-lmer.R
@@ -123,7 +123,7 @@ test_that("lmer", {
     expect_is(lmer(Yield ~ 1|Batch, Dyestuff, control=lmerControl(optimizer="Nelder_Mead")), "lmerMod")
     expect_is(lmer(Yield ~ 1|Batch, Dyestuff, control=lmerControl()), "lmerMod")
     ## avoid _R_CHECK_LENGTH_1_LOGIC2_ errors ...
-    if (getRversion() < "3.6.0" || packageVersion("optimx")>"2018.7.10") {
+    if (getRversion() < "3.6.0" || !requireNamespace("optimx", quietly = TRUE) || packageVersion("optimx")>"2018.7.10") {
         expect_error(lmer(Yield ~ 1|Batch, Dyestuff, control=lmerControl(optimizer="optimx")),"must specify")
         expect_is(lmer(Yield ~ 1|Batch, Dyestuff,
                        control=lmerControl(optimizer="optimx",


### PR DESCRIPTION
We can also do the following I believe:

```
skip_if_not_installed("base", "3.6.0")
skip_if_not_installed("optimx", "2018.7.10")
```

with the caveat that the subsequent of the tests in this `test_that()` unit will also be skipped