### PR TITLE
Update URL for `BLUPS are not best`

### DIFF
--- a/R/bootMer.R
+++ b/R/bootMer.R
@@ -16,7 +16,7 @@
 ##      title = {The {BLUPs} are not "best" when it comes to bootstrapping},
 ##      volume = {56},
 ##      issn = {0167-7152},
-##      url = {http://www.sciencedirect.com/science/article/S016771520200041X},
+##      url = {https://www.sciencedirect.com/science/article/pii/S016771520200041X},
 ##      doi = {10.1016/S0167-7152(02)00041-X},
 ##      journal = {Statistics \& Probability Letters},
 ##      author = {Morris, Jeffrey S},


### PR DESCRIPTION
I was reading the code for bootstrapping and found that one of the links didn't work anymore, so fixing it while I am here.