### PR TITLE
Fix to bug in `binomial_simfun` for factor responses

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -842,8 +842,8 @@ binomial_simfun <- function(object, nsim, ftd=fitted(object),
         y <- model.response(m)
         if(is.factor(y)) {
             ## ignore weights
-            yy <- factor(1+rbinom(ntot, size = 1, prob = ftd),
-                         labels = levels(y))
+            yy <- factor(levels(y)[1 + rbinom(ntot, size = 1, prob = ftd)],
+                         levels = levels(y))
             split(yy, rep(seq_len(nsim), each = n))
         } else if(is.matrix(y) && ncol(y) == 2) {
             yy <- vector("list", nsim)


### PR DESCRIPTION
Error would occur when a factor was simulated, and the simulated data only contained one of the factor levels. 

Reproducible example:

```{r}
library(lme4)
set.seed(1241)
y <- factor(c(rep(0,1000),1,rep(0,1000),1),levels = c("0","1"))
x <- rep(c("A","B"),each = 1001)
mod <- glmer(y ~ 1 + (1|x),family = binomial)
simulate(mod,newdata = data.frame(x = "A"),nsim = 10)
```
Which yields the error
```
Error in factor(1 + rbinom(ntot, size = 1, prob = ftd), labels = levels(y)) : 
  invalid 'labels'; length 2 should be 1 or 1
```
Fix applied which results in the correct behaviour of a factor outputted with multiple levels but all elements equal to the same element.