### PR TITLE
Header clean-up to fix #745

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -31,7 +31,8 @@ cache/.*
 README.md
 TODO.md
 R/TAGS
-src/mcmcsamp.cpp
+src/mcmcsamp\.h$
+src/mcmcsamp\.cpp$
 ^\.github$
 revdep/
 Rplots.pdf

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Description: Fit linear and generalized linear mixed-effects models.
     methods.  The core computational algorithms are implemented using the
     'Eigen' C++ library for numerical linear algebra and 'RcppEigen' "glue".
 Depends: R (>= 3.5.0), Matrix (>= 1.2-1), methods, stats
-LinkingTo: Rcpp (>= 0.10.5), RcppEigen
+LinkingTo: Rcpp (>= 0.10.5), RcppEigen (>= 0.3.3.9.3.2), Matrix
 Imports: graphics, grid, splines, utils, parallel, MASS, lattice, boot,
     nlme (>= 3.1-123), minqa (>= 1.1.15), nloptr (>= 1.0.4)
 Suggests:

--- a/src/lme4CholmodDecomposition.h
+++ b/src/lme4CholmodDecomposition.h
@@ -10,6 +10,7 @@
 #define LME4_CHOLMODDECOMPOSITION_H
 
 #include <RcppEigen.h>
+#include <RcppEigenCholmod.h>
 
 namespace lme4 {
 
@@ -42,8 +43,8 @@ namespace lme4 {
                 // viewAsCholmod(matrix.template selfadjointView<_UpLo>()) :
                 viewAsCholmod(matrix);
 
-            cholmod_factorize_p(&A, &beta, fset.data(), fset.size(),
-                                factor(), &cholmod());
+            R_MATRIX_CHOLMOD(factorize_p)(
+                &A, &beta, fset.data(), fset.size(), factor(), &cholmod());
 
             this->m_info = Eigen::Success;
             m_factorizationIsOk = true;
@@ -59,15 +60,15 @@ namespace lme4 {
             // note: cd stands for Cholmod Dense
             cholmod_dense b_cd = viewAsCholmod(other.const_cast_derived());
             // m_cholmodFactor
-            cholmod_dense* x_cd = cholmod_solve(type, factor(), &b_cd,
-                                                &cholmod());
+            cholmod_dense* x_cd = R_MATRIX_CHOLMOD(solve)(
+                type, factor(), &b_cd, &cholmod());
             if(!x_cd) {
                 this->m_info = Eigen::NumericalIssue;
             }
             typename Base::Scalar* xpt =
                 reinterpret_cast<typename Base::Scalar*>(x_cd->x);
             std::copy(xpt, xpt + other.rows() * other.cols(), other.data());
-            cholmod_free_dense(&x_cd, &cholmod());
+            R_MATRIX_CHOLMOD(free_dense)(&x_cd, &cholmod());
         }
     };
 

--- a/src/predModule.cpp
+++ b/src/predModule.cpp
@@ -6,6 +6,7 @@
 // This file is part of lme4.
 
 #include "predModule.h"
+#include <RcppEigenStubs.cpp>
 
 namespace lme4 {
     using    Rcpp::as;


### PR DESCRIPTION
Note that these changes are entirely conditional on RcppCore/RcppEigen#131, hence `DESCRIPTION` was modified to depend on a patched **RcppEigen** and CRAN submission must be co-ordinated with @eddelbuettel.

Edit: Now I see that **RcppEigen** has `R (>= 3.6.0)` whereas **lme4** has `R (>= 3.5.0)`.  Do we know why **RcppEigen** does not support 3.5.0?