### PR TITLE
Add missing Matrix version dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Description: Fit linear and generalized linear mixed-effects models.
     methods.  The core computational algorithms are implemented using the
     'Eigen' C++ library for numerical linear algebra and 'RcppEigen' "glue".
 Depends: R (>= 3.5.0), Matrix (>= 1.2-1), methods, stats
-LinkingTo: Rcpp (>= 0.10.5), RcppEigen (>= 0.3.3.9.4), Matrix
+LinkingTo: Rcpp (>= 0.10.5), RcppEigen (>= 0.3.3.9.4), Matrix (>= 1.6.2)
 Imports: graphics, grid, splines, utils, parallel, MASS, lattice, boot,
     nlme (>= 3.1-123), minqa (>= 1.1.15), nloptr (>= 1.0.4)
 Suggests:


### PR DESCRIPTION
AFAICT this macro was added in Matrix 1.6.2:

https://github.com/lme4/lme4/blob/2d82cbee952c23e2d3f8492489da7bd5a40dfb2f/src/lme4CholmodDecomposition.h#L72

It _may_ be avoidable by just copying the macro definition:

https://github.com/cran/Matrix/blob/d91a3f2149572d5e4801cb9d4c28d55ffd3642e8/inst/include/Matrix/cholmod.h#L4166-L4168

But not sure if that's hiding some other API pieces that were added at the same time.