### PR TITLE
Fix lookup of optional arguments in lFormula()

### DIFF
--- a/R/modular.R
+++ b/R/modular.R
@@ -374,7 +374,7 @@ lFormula <- function(formula, data=NULL, REML = TRUE,
     ## so they have to be put there:
     for (i in c("weights", "offset")) {
         if (!eval(bquote(missing(x=.(i)))))
-            assign(i,get(i,parent.frame()),environment(fr.form))
+            assign(i,get(i),environment(fr.form))
     }
     mf$formula <- fr.form
     fr <- eval(mf, parent.frame())


### PR DESCRIPTION
`lFormula()` was looking up the argument names `weights` and `offset` in the *caller scope* instead of the current scope. This will fail unless the caller happens to have defined local variables of those exact names.

However, it usually fails *silently*, since `get()` by default uses `inherits = TRUE` and searches through the chain of parent environments, which usually include attached packages. `lFormula()` therefore finds `stats::weights` and `stats::offset`, and by pure (bad) luck these don’t trigger an error even though they’re not of the expected type (functions instead of numeric vectors).

See klmr/box#373.

(I’m aware that this code also contains another issue, discussed in #481, but fixing that is more involved: it is not fixed by this PR.)