### PR TITLE
The Nelder_Mead function accepts the trace option. Also, fn can return NA to stop

### DIFF
--- a/man/Nelder_Mead.Rd
+++ b/man/Nelder_Mead.Rd
@@ -9,11 +9,11 @@
 }
 \usage{
 Nelder_Mead(fn, par, lower = rep.int(-Inf, n), upper = rep.int(Inf, n),
-            control = list())
+            control = list(), trace=FALSE)
 }
 \arguments{
   \item{fn}{a \code{\link{function}} of a single numeric vector argument
-    returning a numeric scalar.}
+    returning a numeric scalar. If the function returns NA, the iteration is stopped.}
 
   \item{par}{numeric vector of starting values for the parameters.}
 
@@ -48,6 +48,8 @@ Nelder_Mead(fn, par, lower = rep.int(-Inf, n), upper = rep.int(Inf, n),
 	Defaults to \code{FALSE}, i.e., stop on non-convergence.}
     }
   }
+  \item{trace}{logical indicating if a trace of the optimization
+    should be kept.}
 }
 \value{
   a \code{\link{list}} with components
@@ -66,6 +68,7 @@ Nelder_Mead(fn, par, lower = rep.int(-Inf, n), upper = rep.int(Inf, n),
   \item{control}{the \code{\link{list}} of control settings after
     substituting for defaults.}
   \item{feval}{the number of function evaluations.}
+  \item{trace}{A dataframe with the iteration number, the fval, and the coordinates X1...Xn (only of trace is TRUE).}
 }
 \seealso{
   The \code{\linkS4class{NelderMead}} class definition and generator


### PR DESCRIPTION
The trace option in the `Nelder_Mead` function allows to get a data frame with the intermediate points. Also, if/when the function to be optimized returns a NA, the iteration stops cleanly.

The latter change allows to use the algorithm interactively, which may prove useful if the function to be optimized is actually an external simulation that you cannot control programmatically. In such a circumstance, you may call:

```r
Nelder_Mead2(\(x) {
    cat("Value at:", x, "\n")
    readline() %>% as.numeric()
    }, p0, trace=T)
```

and just enter `NA` to stop the process earlier, while still keeping trace of the evolution.

Admittedly, it would be great to allow to start the optimization from a simplex, instead from a single point, for this would allow to restart an optimization that has been stopped earlier. But I need to study the codebase more deeply to figure out if that can be done.