### PR TITLE
Fix safe_chol() for PSD matrices using LDL^T fallback (#555)

### DIFF
--- a/tests/testthat/test-vcconv.R
+++ b/tests/testthat/test-vcconv.R
@@ -1,0 +1,68 @@
+library("testthat")
+library("lme4")
+
+context("vcconv - testing safe_chol()")
+
+test_that("safe_chol returns upper triangular matrix for a simple PD matrix", {
+  M <- diag(c(3, 2, 1))
+  L <- lme4:::safe_chol(M)
+  expect_true(all(L[lower.tri(L)] == 0),
+              info = "Matrix L should be upper triangular")
+  expect_equal(crossprod(L), M, tolerance = 1e-8,
+               info = "Reconstructed matrix should match the original PD matrix")
+})
+
+test_that("safe_chol works with a generic PD matrix", {
+  M <- matrix(c(4, 1, 1,
+                1, 3, 2,
+                1, 2, 5), 3, 3)
+  M <- (M + t(M))/2  ## ensure symmetry
+  L <- lme4:::safe_chol(M)
+  expect_true(all(L[lower.tri(L)] == 0),
+              info = "Matrix L should be upper triangular")
+  expect_equal(crossprod(L), M, tolerance = 1e-8,
+               info = "Reconstructed matrix should equal M")
+})
+
+test_that("safe_chol handles a semi-definite (PSD) matrix", {
+  V <- matrix(c(1600, 1160, 1760,
+                1160, 3442, 2806,
+                1760, 2806, 2836), 3, 3)
+  V <- (V + t(V))/2  ## ensure symmetry
+  L <- lme4:::safe_chol(V)
+  expect_true(all(L[lower.tri(L)] == 0),
+              info = "Matrix L should be upper triangular")
+  expect_equal(crossprod(L), V, tolerance = 1e-8,
+               info = "Reconstructed matrix should equal the PSD matrix")
+})
+
+test_that("safe_chol handles a rank-deficient matrix", {
+  V <- matrix(c(1, 0, 0,
+                0, 0, 0,
+                0, 0, 0), 3, 3)
+  L <- lme4:::safe_chol(V)
+  expect_true(all(L[lower.tri(L)] == 0),
+              info = "Matrix L should be upper triangular")
+  expect_equal(crossprod(L), V, tolerance = 1e-8,
+               info = "Reconstructed matrix should equal the rank-deficient matrix")
+})
+
+test_that("safe_chol handles a nearly singular matrix", {
+  eps <- 1e-10
+  M <- matrix(c(1, 1-eps,
+                1-eps, 1), 2, 2)
+  M <- (M + t(M))/2
+  L <- lme4:::safe_chol(M)
+  expect_true(all(L[lower.tri(L)] == 0),
+              info = "Matrix L should be upper triangular")
+  expect_equal(crossprod(L), M, tolerance = 1e-7,
+               info = "Reconstructed matrix should match the nearly singular matrix within tolerance")
+})
+
+test_that("safe_chol throws an error for an indefinite matrix", {
+  Bad <- matrix(c(-1, 0,
+                  0, 2), 2, 2)
+  expect_error(lme4:::safe_chol(Bad),
+               regexp = "chol",
+               info = "safe_chol() should fail for an indefinite matrix")
+})


### PR DESCRIPTION


This pull request addresses #555 regarding the behavior of `safe_chol()` when handling positive semidefinite (PSD) matrices. In the current implementation, when a PSD matrix is encountered, the fallback using a pivoted Cholesky decomposition sometimes returns a factor that is not strictly triangular, even though it satisfies `crossprod(L) == V`. This can lead to unexpected behavior in downstream code that assumes a standard (upper-triangular) Cholesky factor.

  
The function now first attempts a standard Cholesky decomposition. If that fails (indicating a PSD matrix), it falls back on an LDL^T decomposition. In this fallback, we compute the LDL^T factors (with appropriate tolerance checks for near-zero pivots) and then form an upper-triangular factor `U` as follows:
  
  ```
  U = diag(sqrt(D)) %*% t(L)
  ```
  
where `L` is the unit lower-triangular factor from the LDL^T decomposition and `D` is the corresponding diagonal vector. This ensures that:
  
  - `crossprod(U)` approximates the input matrix `V` within a specified tolerance, and  
  - `U` is strictly upper-triangular.

Additional tests have been added in `tests/testthat/test-vcconv.R` to ensure that:
  - For PSD matrices, `safe_chol()` returns a factor whose lower-triangular entries are all zero, and  
  - The reconstruction via `crossprod(L)` matches the original matrix within the defined tolerance.

  
There is nuance in the literature regarding the Cholesky decomposition of PSD matrices. According to [[Wikipedia](https://en.wikipedia.org/wiki/Cholesky_decomposition)](https://en.wikipedia.org/wiki/Cholesky_decomposition), while a unique triangular factor is guaranteed for positive definite matrices, the factorization in the semidefinite case is not unique. In theory, this means that a nontriangular factor might be acceptable. However, within the context of `lme4`, downstream functions and tests expect an upper-triangular factor.
 
- This fix is implemented following discussions with our GSOC mentor @bbolker.  
- Thanks to @pitakakariki for opening the issue and providing valuable input.

Please review the changes and let me know if further modifications are needed. Thank you!

---