### PR TITLE
Refactor isSingular into an S3 Generic #770

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -263,7 +263,7 @@ export(vcov.merMod)
 S3method(vcov,summary.merMod)
 S3method(weights,merMod)
 S3method(xyplot,thpr)
-
+S3method(isSingular, default)
 
 S3method(sigma,lmList4)
 S3method(dfbeta,influence.merMod)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1051,11 +1051,17 @@ initialize.parallel <- expression({
     }
 })
 
-isSingular <- function(x, tol = 1e-4) {
-    lwr <- getME(x, "lower")
-    theta <- getME(x, "theta")
-    any(theta[lwr==0] < tol)
+isSingular <- function(x, tol = 1e-4, ...) {
+  UseMethod("isSingular")
 }
+
+isSingular.default <- function(x, tol = 1e-4, ...) {
+  lwr <- getME(x, "lower")
+  theta <- getME(x, "theta")
+  any(theta[lwr == 0] < tol)
+}
+
+
 
 lme4_testlevel <- function() if (nzchar(s <- Sys.getenv("LME4_TEST_LEVEL"))) as.numeric(s) else 1
 


### PR DESCRIPTION
**Issue Addressed:** This pull request refactors the isSingular function to be an S3 generic, allowing for method dispatch based on the class of the model object. Users and developers can now define class-specific behaviors for singularity checks.This method is to address issue [lme4 Issue #770](https://github.com/lme4/lme4/issues/770) #770 

**How it works:**
Existing code using isSingular() will continue to work as it now dispatches to isSingular.default if no class-specific method is available.

**Next Step:** Consider extending class-specific methods for additional model classes as needed.


