### PR TITLE
Attempt at improving the documentation for plot.merMod.Rd.

### DIFF
--- a/man/lmer.Rd
+++ b/man/lmer.Rd
@@ -149,12 +149,14 @@ lmer(formula, data = NULL, REML = TRUE, control = lmerControl(),
 \seealso{
   \code{\link[stats]{lm}} for linear models;
   \code{\link{glmer}} for generalized linear; and
-  \code{\link{nlmer}} for nonlinear mixed models.
+  \code{\link{nlmer}} for nonlinear mixed models. \cr
+  \code{\link{plot.merMod}} for plot diagnostics.
 }
 \examples{
 ## linear mixed models - reference values from older code
 (fm1 <- lmer(Reaction ~ Days + (Days | Subject), sleepstudy))
-summary(fm1)# (with its own print method; see class?merMod % ./merMod-class.Rd
+summary(fm1) # (with its own print method; see class?merMod % ./merMod-class.Rd
+plot(fm1) # plotting the model diagnostics; see ?plot.merMod
 
 str(terms(fm1))
 stopifnot(identical(terms(fm1, fixed.only=FALSE),

--- a/man/plot.merMod.Rd
+++ b/man/plot.merMod.Rd
@@ -2,6 +2,16 @@
 \title{Diagnostic Plots for 'merMod' Fits}
 \alias{plot.merMod}
 \alias{qqmath.merMod}
+\alias{diagnostics}
+\alias{diagnostic.plots}
+\alias{diagnosticPlots}
+\alias{diagnostic_plots}
+\alias{plot.diagnostics}
+\alias{plotDiagnostics}
+\alias{plot_diagnodtics}
+\alias{model.diagnostics}
+\alias{modelDiagnostics}
+\alias{model_diagnostics}
 \usage{
 \method{plot}{merMod}(x,
      form = resid(., type = "pearson") ~ fitted(.), abline,
@@ -9,7 +19,7 @@
 \method{qqmath}{merMod}(x, data = NULL, id = NULL, idLabels = NULL, \dots)
 }
 \arguments{
-  \item{x}{a fitted [ng]lmer model}
+  \item{x}{a fitted [ng]lmer model.}
   \item{form}{an optional formula specifying the desired
   type of plot. Any variable present in the original data
   frame used to obtain \code{x} can be referenced. In
@@ -53,7 +63,7 @@
   formula \code{idLabels=~.obs} will label the observations
   according to observation number.}
 
-  \item{data}{ignored: required for S3 method compatibility}
+  \item{data}{ignored: required for S3 method compatibility.}
   \item{grid}{an optional logical value indicating whether
   a grid should be added to plot. Default depends on the
   type of lattice plot used: if \code{xyplot} defaults to
@@ -63,7 +73,10 @@
   plot function.}
 }
 \description{
-  diagnostic plots for merMod fits
+  diagnostic plots for merMod fits. Some of these plots are basic 
+  and may be supplemented or superseded by functions from other 
+  packages. See the \emph{See Also} section below for recommended 
+  alternatives.
 }
 \details{
   Diagnostic plots for the linear mixed-effects fit are
@@ -88,7 +101,13 @@
   (see \code{\link{qqmath.ranef.mer}} for Q-Q plots of the
   conditional mode values).
 }
-\seealso{\code{influencePlot} in the \code{car} package}
+\seealso{
+  \code{\link[performance]{check_model}} in the \code{performance} package. \cr
+  \code{DHARMa} package, which evaluates model diagnostics through 
+  simulating residuals (see: \code{\link[DHARMa]{simulateResiduals}}). \cr
+  \code{\link[lattice]{qqmath}} in the \code{lattice} package. \cr
+  \code{\link[car]{influencePlot}} in the \code{car} package. \cr
+}
 \author{
   original version in \CRANpkg{nlme} package by Jose Pinheiro
   and Douglas Bates.


### PR DESCRIPTION
My attempt at dealing with this current lme4 issue as stated here: https://github.com/lme4/lme4/issues/468 

In summary,
- very slightly modified lmer.Rd to mention diagnostic plots and refer to plot.merMod.Rd
- modified plot.merMod.Rd by adding references to \seealso, as well as the description header telling the user to visit \seealso. Also added links for external packages
