### PR TITLE
Changing the oldNames argument in confint to be consistent with profile

### DIFF
--- a/R/profile.R
+++ b/R/profile.R
@@ -796,23 +796,27 @@ confint.thpr <- function(object, parm, level = 0.95, zeta,
 ##' @param nsim number of simulations for parametric bootstrap intervals
 ##' @param boot.type bootstrap confidence interval type
 ##' @param quiet (logical) suppress messages about computationally intensive profiling?
-##' @param oldNames (logical) use old-style names for \code{method="profile"}? (See \code{signames} argument to \code{\link{profile}}
+##' @param signames (logical) use old-style names for \code{method="profile"}? (See \code{signames} argument to \code{\link{profile}}
 ##' @param \dots additional parameters to be passed to  \code{\link{profile.merMod}} or \code{\link{bootMer}}
 ##' @return a numeric table of confidence intervals
 confint.merMod <- function(object, parm, level = 0.95,
                            method = c("profile","Wald","boot"),
                            zeta, nsim=500, boot.type = c("perc","basic","norm"),
-                           FUN = NULL, quiet=FALSE, oldNames=TRUE, ...)
+                           FUN = NULL, quiet=FALSE, oldNames=NULL, signames = TRUE, ...)
 {
     method <- match.arg(method)
     boot.type <- match.arg(boot.type)
+    if (!is.null(oldNames)) {
+      warning("'oldNames' will be deprecated. Please use 'signames' instead.", call. = FALSE)
+      signames <- oldNames
+    }
     ## 'parm' corresponds to 'which' in other contexts
     if (method=="boot" && !is.null(FUN)) {
         ## custom boot function, don't expand parameter names
     } else {
         ## "use scale" = GLMM with scale parameter *or* LMM ..
         useSc <- as.logical(object@devcomp$dims[["useSc"]])
-        vn <- profnames(object, oldNames, useSc=useSc)
+        vn <- profnames(object, signames, useSc=useSc)
         an <- c(vn,names(fixef(object)))
         parm <- if(missing(parm)) seq_along(an)
                 else
@@ -825,7 +829,7 @@ confint.merMod <- function(object, parm, level = 0.95,
     }
     switch(method,
            "profile" = {
-               pp <- profile(object, which=parm, signames=oldNames, ...)
+               pp <- profile(object, which=parm, signames=signames, ...)
                ## confint.thpr() with missing(parm) using all names:
                confint(pp, level=level, zeta=zeta)
            },

--- a/man/confint.merMod.Rd
+++ b/man/confint.merMod.Rd
@@ -41,9 +41,9 @@
     are unavailable because they require additional components to be
     calculated.)}
   \item{quiet}{(logical) suppress messages about computationally intensive profiling?}
-  \item{oldNames}{(logical) use old-style names for variance-covariance
-    parameters, e.g. \code{".sig01"}, rather than newer (more informative) names such as
-    \code{"sd_(Intercept)|Subject"}? (See \code{signames} argument to
+  \item{signames}{(logical) indicates if abbreviated names of the form
+    \code{.sigNN} rather than newer (more informative) names such as
+    \code{"sd_(Intercept)|Subject"}. (See \code{signames} argument to
     \code{\link{profile}}).}
   \item{non.mono.tol}{tolerance for detecting a non-monotonic profile
     and warning/falling back to linear interpolation}


### PR DESCRIPTION
This pertains to this issue: https://github.com/lme4/lme4/issues/774 

In summary, what I did was use signames for both, added a warning that oldNames will be depreciated, changed the documentation to account for the new argument. My rationale:

1. Personally I think "signames" is better than "oldNames" because it provides a better description of what form the names look like.
2.  Using periods such as “sig.names” or “old.names” might change too much. This doesn’t really seem that standardized across the board either; some people prefer underscores.
3. Should probably provide a warning to give people time to adjust, and also, for their code to run. Probably should remove the warning message in a couple years.