### PR TITLE
allFit Update to Allow Initialization from Model's MLE

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -15,7 +15,9 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
-    if: "contains(github.event.head_commit.message, '[run ci]')"
+    if: |
+      github.event.name == "pull_request" ||
+       contains(github.event.head_commit.message, '[run ci]')
 
     runs-on: ${{ matrix.config.os }}
 
@@ -35,6 +37,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      LME4_TEST_LEVEL: 2
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -15,8 +15,7 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
-    if: |
-      github.event.name == "pull_request" ||
+    if: github.event.name == 'pull_request' ||
        contains(github.event.head_commit.message, '[run ci]')
 
     runs-on: ${{ matrix.config.os }}

--- a/R/allFit.R
+++ b/R/allFit.R
@@ -68,7 +68,7 @@ nmkbw <- function(fn, par, lower, upper, control) {
 ##' @param verbose print progress messages?
 ##' @param catch.err catch errors?
 ##' @param start_from_mle logical; determines whether to initialize the 
-##'   refitting process using starting values from the model’s mle.
+##'   refitting process using starting values from the model’s MLE.
 ##' @return a list of fitted \code{merMod} objects
 ##' @seealso slice, slice2D in the bbmle package
 ##' @examples
@@ -174,8 +174,10 @@ allFit <- function(object, meth.tab = NULL,
               if (isGLMM(object)) {
                 pars <- getME(object, c("theta", "fixef"))
               } else {
-                # TODO: may need support for nlme and other object types...
                 pars <- getME(object, "theta")
+                if(is.NLMM(object)){
+                  warning("results are not guaranteed when using nlmer")
+                }
               }
             }
             

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -18,6 +18,9 @@
       \item changed \code{confint.merMod} to use \code{signames} as an
       argument instead of \code{oldNames} to be consistent with
       \code{profile.merMod}
+      \item added a new argument \code{start_from_mle} to \code{allFit} so
+      the user may initialize the refitting process using starting values 
+      from the model’s MLE.
     } % itemize
   } % user-visible changes
 } % devel

--- a/man/allFit.Rd
+++ b/man/allFit.Rd
@@ -2,21 +2,22 @@
 \alias{allFit}
 \title{Refit a fitted model with all available optimizers}
 \usage{
-allFit(object, meth.tab = NULL, data=NULL,
+allFit(object, meth.tab = NULL, data = NULL,
        verbose = TRUE,
        show.meth.tab = FALSE,
        maxfun = 1e5,
        parallel = c("no", "multicore", "snow"),
        ncpus = getOption("allFit.ncpus", 1L), cl = NULL,
-       catch.errs = TRUE)
+       catch.errs = TRUE,
+       start_from_mle = NULL)
 }
 \arguments{
-  \item{object}{a fitted model}
-  \item{meth.tab}{a matrix (or data.frame) with columns
+  \item{object}{a fitted model.}
+  \item{meth.tab}{a matrix (or data.frame) with columns.
     \describe{
       \item{method}{the name of a specific optimization method to pass
-	to the optimizer (leave blank for built-in optimizers)}
-      \item{optimizer}{the \code{optimizer} function to use}
+	to the optimizer (leave blank for built-in optimizers).}
+      \item{optimizer}{the \code{optimizer} function to use.}
     }
   }
   \item{data}{data to be included with result (for later debugging etc.)}
@@ -25,7 +26,7 @@ allFit(object, meth.tab = NULL, data=NULL,
   \item{maxfun}{passed as part of \code{optCtrl} to set the maximum
     number of function evaluations: this is \emph{automatically}
     converted to the correct specification (e.g. \code{maxfun},
-    \code{maxfeval}, \code{maxit}, etc.) for each optimizer}
+    \code{maxfeval}, \code{maxit}, etc.) for each optimizer.}
   \item{parallel}{The type of parallel operation to be used (if any).
     If missing, the
     default is taken from the option \code{"boot.parallel"} (and if that
@@ -37,9 +38,11 @@ allFit(object, meth.tab = NULL, data=NULL,
   \item{cl}{An optional \pkg{parallel} or \pkg{snow} cluster for use if
     \code{parallel = "snow"}.  If not supplied, a cluster on the
     local machine is created for the duration of the \code{boot} call.}
-  \item{catch.errs}{(logical) Wrap model fits in \code{tryCatch} clause
+  \item{catch.errs}{logical: wrap model fits in \code{tryCatch} clause
     to skip over errors? (\code{catch.errs=FALSE} is probably only
-    useful for debugging)}
+    useful for debugging).}
+  \item{start_from_mle}{logical: if \code{TRUE}, initialize the 
+    refitting process using starting values from the model’s MLE.}
 }
 \value{
   an object of type \code{allFit}, which is a list of fitted \code{merMod} objects (unless \code{show.meth.tab} is
@@ -64,13 +67,13 @@ this appears as \sQuote{nmkbw} in \code{meth.tab})
 }
 \details{
 \itemize{
-\item Needs packages \code{optimx}, and \code{dfoptim} to use all optimizers
+\item Needs packages \code{optimx}, and \code{dfoptim} to use all optimizers.
 \item If you are using \code{parallel="snow"} (e.g. when running in
 parallel on Windows), you will need to set up a cluster yourself and run
 \code{clusterEvalQ(cl,library("lme4"))} before calling
 \code{allFit} to make sure that the
-\code{lme4} package is loaded on all of the workers
-\item Control arguments in \code{control$optCtrl} that are unused by a particular optimizer will be \emph{silently} ignored (in particular, the \code{maxfun} specification is only respected by \code{bobyqa}, \code{Nelder_Mead}, and \code{nmkbw})
+\code{lme4} package is loaded on all of the workers.
+\item Control arguments in \code{control$optCtrl} that are unused by a particular optimizer will be \emph{silently} ignored (in particular, the \code{maxfun} specification is only respected by \code{bobyqa}, \code{Nelder_Mead}, and \code{nmkbw}).
 \item Because \code{allFit} works by calling \code{update}, it may be fragile if the original model call contains references to variables, especially if they were originally defined in other environments or no longer exist when \code{allFit} is called.
 }
 }

--- a/man/allFit.Rd
+++ b/man/allFit.Rd
@@ -9,7 +9,7 @@ allFit(object, meth.tab = NULL, data = NULL,
        parallel = c("no", "multicore", "snow"),
        ncpus = getOption("allFit.ncpus", 1L), cl = NULL,
        catch.errs = TRUE,
-       start_from_mle = NULL)
+       start_from_mle = TRUE)
 }
 \arguments{
   \item{object}{a fitted model.}

--- a/man/allFit.Rd
+++ b/man/allFit.Rd
@@ -21,8 +21,8 @@ allFit(object, meth.tab = NULL, data = NULL,
     }
   }
   \item{data}{data to be included with result (for later debugging etc.)}
-  \item{verbose}{logical: report progress in detail?}
-  \item{show.meth.tab}{logical: return table of methods?}
+  \item{verbose}{(logical) report progress in detail?}
+  \item{show.meth.tab}{(logical) return table of methods?}
   \item{maxfun}{passed as part of \code{optCtrl} to set the maximum
     number of function evaluations: this is \emph{automatically}
     converted to the correct specification (e.g. \code{maxfun},
@@ -38,10 +38,10 @@ allFit(object, meth.tab = NULL, data = NULL,
   \item{cl}{An optional \pkg{parallel} or \pkg{snow} cluster for use if
     \code{parallel = "snow"}.  If not supplied, a cluster on the
     local machine is created for the duration of the \code{boot} call.}
-  \item{catch.errs}{logical: wrap model fits in \code{tryCatch} clause
+  \item{catch.errs}{(logical) wrap model fits in \code{tryCatch} clause
     to skip over errors? (\code{catch.errs=FALSE} is probably only
     useful for debugging).}
-  \item{start_from_mle}{logical: if \code{TRUE}, initialize the 
+  \item{start_from_mle}{(logical) if \code{TRUE}, initialize the 
     refitting process using starting values from the model’s MLE.}
 }
 \value{

--- a/man/allFit.Rd
+++ b/man/allFit.Rd
@@ -1,6 +1,6 @@
 \name{allFit}
 \alias{allFit}
-\title{Refit a fitted model with all available optimizers}
+\title{Refit a fitted model with all available optimizers to check convergence}
 \usage{
 allFit(object, meth.tab = NULL, data = NULL,
        verbose = TRUE,

--- a/tests/testthat/test-allFit.R
+++ b/tests/testthat/test-allFit.R
@@ -6,10 +6,18 @@ if (testLevel>1) {
     L <- load(system.file("testdata", "lme-tst-fits.rda",
                           package="lme4", mustWork=TRUE))
 
-    gm_all <- allFit(fit_cbpp_1, verbose=FALSE)
+    gm_all <- allFit(fit_cbpp_1, verbose=TRUE)
+    gm_all_nostart <- allFit(fit_cbpp_1, verbose=FALSE, start_from_mle = FALSE)
 
+    summary(gm_all)$times[,"elapsed"]
+    summary(gm_all_nostart)$times[,"elapsed"]
 
-    context("Show basic allFit results")
+  ## library(microbenchmark)
+  ##  mb1 <- microbenchmark(
+  ##   start = allFit(fit_cbpp_1, verbose=FALSE),
+  ##   nostart = allFit(fit_cbpp_1, verbose=FALSE, start_from_mle = FALSE)
+  ##  )
+
     test_that("allFit print/summary is fine", {
         expect_is(gm_all, "allFit")
         expect_is(summary(gm_all), "summary.allFit")
@@ -96,7 +104,7 @@ if (testLevel>1) {
         v <- vapply(gm_it10, function(x) as.integer(x@optinfo$feval), FUN.VALUE=1L)
         ## function values are sometimes off a bit (due to initialization or Hessian calculation)
         ##  but close enough ...
-        expect_true(all(v %in% c(10, 11, NA, 18)))
+        expect_true(all(is.na(v) | v < 12))
     })
 
 

--- a/tests/testthat/test-allFit.R
+++ b/tests/testthat/test-allFit.R
@@ -1,16 +1,19 @@
 testLevel <- if (nzchar(s <- Sys.getenv("LME4_TEST_LEVEL"))) as.numeric(s) else 1
 if (testLevel>1) {
 
-    library("testthat")
-    library("lme4")
-    L <- load(system.file("testdata", "lme-tst-fits.rda",
-                          package="lme4", mustWork=TRUE))
+  library("testthat")
+  library("lme4")
+  L <- load(system.file("testdata", "lme-tst-fits.rda",
+                        package="lme4", mustWork=TRUE))
+  
+  gm_all <- allFit(fit_cbpp_1, verbose=TRUE)
+  gm_all_nostart <- allFit(fit_cbpp_1, verbose=FALSE, start_from_mle = FALSE)
 
-    gm_all <- allFit(fit_cbpp_1, verbose=TRUE)
-    gm_all_nostart <- allFit(fit_cbpp_1, verbose=FALSE, start_from_mle = FALSE)
+  summary(gm_all)$times[,"elapsed"]
+  summary(gm_all_nostart)$times[,"elapsed"]
 
-    summary(gm_all)$times[,"elapsed"]
-    summary(gm_all_nostart)$times[,"elapsed"]
+  sapply(gm_all, function(x) x@optinfo$feval)
+  sapply(gm_all_nostart, function(x) x@optinfo$feval)
 
   ## library(microbenchmark)
   ##  mb1 <- microbenchmark(


### PR DESCRIPTION
allFit Update to Allow Initialization from Model's MLE

This pull request is related to issue https://github.com/lme4/lme4/issues/724.

In summary: added a new argument `start_from_mle` to `allFit` so the user may initialize 
the refitting process using starting values from the model’s MLE. 

Example of use:
```
gm1 <- glmer(cbind(incidence, size - incidence) ~ period + (1 | herd),
             data = cbpp, family = binomial)
## show available methods
allFit(show.meth.tab=TRUE) 
gm_all1 <- allFit(gm1)
ss1 <- summary(gm_all1)

gm_all2 <- allFit(gm1, start_from_mle = TRUE)
ss2 <- summary(gm_all2)

ss1
ss2
```


Extra:

1. I made minor changes in the documentation in `allFit()` to be a bit more consistent. I.e., I noticed `logical: ...` and `(logical) ...` are used. Switched to ensure all followed the former.
2.  I checked to see if `allFit()` works fine on a Window machine (see issue https://github.com/lme4/lme4/issues/554) and things are working fine, including the version in this pull request!