### PR TITLE
Final cleanup for arguments in confint & minor testthat revisions

### DIFF
--- a/tests/testthat/test-NAhandling.R
+++ b/tests/testthat/test-NAhandling.R
@@ -1,6 +1,6 @@
 stopifnot(require("testthat"), require("lme4"))
 
-context("NA (and Inf) handling")
+#context("NA (and Inf) handling")
 
 ## Modified sleepstudy data :
 sleepst.a <- sleepstudy

--- a/tests/testthat/test-allFit.R
+++ b/tests/testthat/test-allFit.R
@@ -1,8 +1,6 @@
 testLevel <- if (nzchar(s <- Sys.getenv("LME4_TEST_LEVEL"))) as.numeric(s) else 1
 if (testLevel>1) {
 
-  library("testthat")
-  library("lme4")
   L <- load(system.file("testdata", "lme-tst-fits.rda",
                         package="lme4", mustWork=TRUE))
   

--- a/tests/testthat/test-catch.R
+++ b/tests/testthat/test-catch.R
@@ -1,7 +1,4 @@
-library("testthat")
-library("lme4")
-
-context("storing warnings, convergence status, etc.")
+#context("storing warnings, convergence status, etc.")
 
 test_that("storewarning", {
     gCtrl <- glmerControl(optimizer = "Nelder_Mead",

--- a/tests/testthat/test-doubleVertNotation.R
+++ b/tests/testthat/test-doubleVertNotation.R
@@ -1,7 +1,4 @@
-library("lme4")
-library("testthat")
-
-context("testing '||' notation for independent ranefs")
+#context("testing '||' notation for independent ranefs")
 
 test_that("basic intercept + slope '||' works", {
 	expect_equivalent(

--- a/tests/testthat/test-factors.R
+++ b/tests/testthat/test-factors.R
@@ -1,7 +1,3 @@
-library("testthat")
-library("lme4")
-
-
 test_that("factors", {
 
     set.seed(101)

--- a/tests/testthat/test-formulaEval.R
+++ b/tests/testthat/test-formulaEval.R
@@ -1,7 +1,4 @@
-library("testthat")
-library("lme4")
-
-context("data= argument and formula evaluation")
+#context("data= argument and formula evaluation")
 
 ## intercept context-dependent errors ... it's too bad that
 ##  these errors differ between devtools::test() and

--- a/tests/testthat/test-glmFamily.R
+++ b/tests/testthat/test-glmFamily.R
@@ -1,6 +1,3 @@
-library("testthat")
-library("lme4") # Needed for last test.
-
 eps <- .Machine$double.eps
 oneMeps <- 1 - eps
 set.seed(1)
@@ -149,13 +146,13 @@ dd1 <- simfun_gam(seed = 101)
 dd2 <- simfun_gam(seed = 101, use_simulate = TRUE)
 
 test_that("simulated Gamma data matches with simulate()", {
-  testthat::expect_equal(dd1$y, dd2$y)
+  expect_equal(dd1$y, dd2$y)
 })
 
 test_that("estimated Gamma dispersion (shape) is correct", {
   m1 <- glmer(y ~ 1 + (1|group), family = Gamma(link = "log"), data = dd2)
   shape_val <- 1/sigma(m1)^2
-  testthat::expect_equal(shape_val, 2.0, tolerance = 0.05)
-  testthat::expect_equal(1/sigma(m1)^2, 1.94511502080571, tolerance = 1e-6)
+  expect_equal(shape_val, 2.0, tolerance = 0.05)
+  expect_equal(1/sigma(m1)^2, 1.94511502080571, tolerance = 1e-6)
 })
 

--- a/tests/testthat/test-glmer.R
+++ b/tests/testthat/test-glmer.R
@@ -1,5 +1,3 @@
-library("testthat")
-library("lme4")
 source(system.file("testdata", "lme-tst-funs.R", package="lme4", mustWork=TRUE))# -> uc() [back-compatible c()]
 testLevel <- lme4:::testLevel()
 
@@ -33,7 +31,7 @@ gives_error_or_warning <- function (regexp = NULL, all = FALSE, ...)
     ## expect_that(warning("bar"),gives_error_or_warning("foo"))
 
 if(testLevel > 1) {
-context("fitting glmer models")
+#context("fitting glmer models")
 test_that("glmer", {
     set.seed(101)
     d <- data.frame(z=rbinom(200,size=1,prob=0.5),

--- a/tests/testthat/test-glmernb.R
+++ b/tests/testthat/test-glmernb.R
@@ -1,5 +1,3 @@
-library("testthat")
-library("lme4")
 testLevel <- if (nzchar(s <- Sys.getenv("LME4_TEST_LEVEL"))) as.numeric(s) else 1
 
 if (testLevel>1) {

--- a/tests/testthat/test-glmernb.R
+++ b/tests/testthat/test-glmernb.R
@@ -1,7 +1,7 @@
 testLevel <- if (nzchar(s <- Sys.getenv("LME4_TEST_LEVEL"))) as.numeric(s) else 1
 
 if (testLevel>1) {
-context("glmer.nb")
+#context("glmer.nb")
 test_that("basic", {
    set.seed(101)
    dd <- expand.grid(f1 = factor(1:3),

--- a/tests/testthat/test-glmernbref.R
+++ b/tests/testthat/test-glmernbref.R
@@ -1,4 +1,3 @@
-library(testthat)
 ## DON'T load lme4; test is to see if glmer.nb works when
 ## lme4 is not loaded
 ## this does *not* work properly in a devtools::test environment

--- a/tests/testthat/test-glmmFail.R
+++ b/tests/testthat/test-glmmFail.R
@@ -1,5 +1,3 @@
-library("testthat")
-## library("lme4")
 data("sleepstudy", package = "lme4")
 
 source(system.file("testdata/lme-tst-funs.R", package="lme4", mustWork=TRUE))

--- a/tests/testthat/test-glmmFail.R
+++ b/tests/testthat/test-glmmFail.R
@@ -8,7 +8,7 @@ dBc <- gSim(family=binomial(link="cloglog"), nbinom = 1) # {0,1} Binomial
 
 ## m1 <- glmer(cbind(incidence, size - incidence) ~ period + (1 | herd),
 ##             family = binomial, data = cbpp)
-context("Errors and warnings from glmer")
+#context("Errors and warnings from glmer")
 test_that("glmer", {
     expect_error(glmer(y ~ 1 + (1|block), data=dBc, family=binomial(link="cloglog")),
                  "Response is constant")

--- a/tests/testthat/test-lmList.R
+++ b/tests/testthat/test-lmList.R
@@ -3,7 +3,7 @@ if ("sample.kind" %in% names(formals(RNGkind))) {
     suppressWarnings(RNGkind("Mersenne-Twister", "Inversion", "Rounding"))
 }
 
-context("lmList")
+#context("lmList")
 test_that("basic lmList", {
     set.seed(17)
     fm1. <- lmList(Reaction ~ Days | Subject, sleepstudy, pool=FALSE)

--- a/tests/testthat/test-lmList.R
+++ b/tests/testthat/test-lmList.R
@@ -1,6 +1,3 @@
-library(lme4)
-library(testthat)
-
 ## use old (<=3.5.2) sample() algorithm if necessary
 if ("sample.kind" %in% names(formals(RNGkind))) {
     suppressWarnings(RNGkind("Mersenne-Twister", "Inversion", "Rounding"))

--- a/tests/testthat/test-lmer.R
+++ b/tests/testthat/test-lmer.R
@@ -6,7 +6,7 @@ if ("sample.kind" %in% names(formals(RNGkind))) {
     suppressWarnings(RNGkind("Mersenne-Twister", "Inversion", "Rounding"))
 }
 
-context("fitting lmer models")
+#context("fitting lmer models")
 ## is "Nelder_Mead" default optimizer? -- no longer
 (isNM <- formals(lmerControl)$optimizer == "Nelder_Mead")
 
@@ -280,7 +280,6 @@ test_that("coef_lmer", {
                     var1=factor(sample(1:5,size=100,replace=TRUE)),
                     var2=runif(100),
                     var3=factor(sample(1:5,size=100,replace=TRUE)))
-    library(lme4)
     mix1 <- lmer(resp ~ 0 + var1 + var1:var2 + (1|var3), data=d)
     c1 <- coef(mix1)
     expect_is(c1, "coef.mer")
@@ -328,7 +327,7 @@ test_that("better info about optimizer convergence",
                  "optimizer (Nelder_Mead) convergence code: 0 (OK)")
 })
 
-context("convergence warnings etc.")
+#context("convergence warnings etc.")
 
 fm1 <- lmer(Reaction~ Days + (Days|Subject), sleepstudy)
 suppressMessages(fm0 <- lmer(Reaction~ Days + (Days|Subject), sleepstudy[1:20,]))

--- a/tests/testthat/test-lmer.R
+++ b/tests/testthat/test-lmer.R
@@ -1,5 +1,3 @@
-stopifnot(require("testthat"))
-library(lme4) ## make sure package is attached
 ##  (as.function.merMod() assumes it)
 data("Dyestuff", package = "lme4")
 

--- a/tests/testthat/test-lmerResp.R
+++ b/tests/testthat/test-lmerResp.R
@@ -1,5 +1,3 @@
-library("lme4")
-library("testthat")
 
 data(Dyestuff, package="lme4")
 n     <- nrow(Dyestuff)
@@ -8,7 +6,7 @@ zeros <- rep.int(0, n)
 YY    <- Dyestuff$Yield
 mYY   <- mean(YY)
 
-context("lmerResp objects")
+#context("lmerResp objects")
 test_that("lmerResp", {
     mres  <- YY - mYY
     rr    <- lmerResp$new(y=YY)

--- a/tests/testthat/test-lmerResp.R
+++ b/tests/testthat/test-lmerResp.R
@@ -28,7 +28,7 @@ test_that("lmerResp", {
 mlYY <- mean(log(YY))
 gmeanYY <- exp(mlYY)                    # geometric mean
 
-context("glmResp objects")
+#context("glmResp objects")
 test_that("glmResp", {
     mres  <- YY - gmeanYY
     gmean <- rep.int(gmeanYY, n)

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -184,7 +184,7 @@ test_that("anova() of glmer+glm models", {
   })
 
 if (testLevel>1) {
-  context("bootMer confint()")
+  #context("bootMer confint()")
   set.seed(47)
   test_that("bootMer", {
     ## testing bug-fix for ordering of sd/cor components in sd/cor matrix with >2 rows
@@ -404,7 +404,7 @@ test_that("refit", {
 })
 
 if (testLevel>1) {
-  context("predict method")
+  #context("predict method")
   test_that("predict", {
     ## when running via source(), cbpp has been corrupted at this point
     ## (replaced by a single empty factor obs()
@@ -653,7 +653,7 @@ if (testLevel>1) {
 
   })
 
-  context("misc")
+  #context("misc")
   test_that("misc", {
     expect_equal(df.residual(fm1),176)
     if (suppressWarnings(require(ggplot2))) {
@@ -666,7 +666,7 @@ if (testLevel>1) {
   })
 } ## testLevel>1
 
-context("plot")
+#context("plot")
 test_that("plot", {
   ## test getData() within plot function: reported by Dieter Menne
   doFit <- function(){
@@ -695,7 +695,7 @@ test_that("plot", {
   expect_warning(lattice::qqmath(fm2, 0.05),          "please specify")
 })
 
-context("misc")
+#context("misc")
 test_that("summary", {
   ## test that family() works when $family element is weird
   ## FIXME: is convergence warning here a false positive?
@@ -707,7 +707,7 @@ test_that("summary", {
 
 
 if (testLevel>1) {
-  context("profile")
+  #context("profile")
   test_that("profile", {
     ## FIXME: can we deal with convergence warning messages here ... ?
     ## fit profile on default sd/cor scale ...
@@ -754,7 +754,7 @@ if (testLevel>1) {
 
 } ## testLevel>1
 
-context("model.frame")
+#context("model.frame")
 test_that("model.frame", {
   ## non-syntactic names
   d <- sleepstudy
@@ -773,7 +773,7 @@ test_that("model.frame", {
 })
 
 
-context("influence measures")
+#context("influence measures")
 
 d <- as.data.frame(ChickWeight)
 colnames(d) <- c("y", "x", "subj", "tx")

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -1,5 +1,3 @@
-library("testthat")
-library("lme4")
 (testLevel <- if (nzchar(s <- Sys.getenv("LME4_TEST_LEVEL"))) as.numeric(s) else 1)
 
 ## use old (<=3.5.2) sample() algorithm if necessary

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -944,3 +944,8 @@ if (testLevel > 1) withAutoprint({
   expect_equal(cooks.distance(fm2), cooks.distance(fm2L), tolerance = 1e-2)
   })
 }) ## testLevel > 1
+
+test_that("oldNames warning in confint", {
+  fm1 <- lmer(Reaction ~ Days + (Days|Subject), sleepstudy)
+  expect_warning(confint(fm1, oldNames = TRUE))
+})

--- a/tests/testthat/test-nbinom.R
+++ b/tests/testthat/test-nbinom.R
@@ -30,7 +30,7 @@ test_that("ok with Poisson masking", {
 })
 
 if (testLevel>2) {
-context("testing glmer refit")
+#context("testing glmer refit")
 
 test_that("glmer refit", {
             ## basic Poisson fit

--- a/tests/testthat/test-nbinom.R
+++ b/tests/testthat/test-nbinom.R
@@ -1,5 +1,3 @@
-library("lme4")
-library("testthat")
 testLevel <- if (nzchar(s <- Sys.getenv("LME4_TEST_LEVEL"))) as.numeric(s) else 1
 
 set.seed(101)

--- a/tests/testthat/test-nlmer.R
+++ b/tests/testthat/test-nlmer.R
@@ -1,8 +1,6 @@
-library("testthat")
-library("lme4")
 testLevel <- if (nzchar(s <- Sys.getenv("LME4_TEST_LEVEL"))) as.numeric(s) else 1
 
-context("lower/upper bounds on nlmer models")
+#context("lower/upper bounds on nlmer models")
 test_that("nlmer", {
     startvec <- c(Asym = 200, xmid = 725, scal = 350)
     nm1 <- nlmer(circumference ~ SSlogis(age, Asym, xmid, scal) ~ Asym|Tree,

--- a/tests/testthat/test-oldRZXfailure.R
+++ b/tests/testthat/test-oldRZXfailure.R
@@ -1,5 +1,3 @@
-library(lme4)
-library(testthat)
 load(system.file("testdata","crabs_randdata00.Rda",package="lme4"))
 
 test_that('RZX is being calculated properly', {

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -28,7 +28,7 @@ if (getRversion() > "3.0.0") {
 }
 
 if (testLevel>1) {
-context("predict")
+#context("predict")
 test_that("fitted values", {
     p0 <- predict(gm1)
     p0B <- predict(gm1, newdata=cbpp)

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -1,5 +1,3 @@
-library("testthat")
-library("lme4")
 library("lattice")
 testLevel <- if (nzchar(s <- Sys.getenv("LME4_TEST_LEVEL"))) as.numeric(s) else 1
 

--- a/tests/testthat/test-ranef.R
+++ b/tests/testthat/test-ranef.R
@@ -13,7 +13,7 @@ d$y <- suppressMessages(simulate(~1+x+(1|f)+(x|g),family=binomial,
                                                 theta=c(1,1,2,1)))[[1]])
 fm1 <- glmer(y~(1|f)+(x|g),family=binomial,data=d)
 
-context("ranef")
+#context("ranef")
 test_that("warn extra args", {
     expect_warning(ranef(fm1,transf=exp),"additional arguments")
 })
@@ -56,7 +56,7 @@ test_that("cbpp consistent with lme4.0", {
     expect_equal(lme4.0condVarcbpp, lme4condVarcbpp, tolerance = 1e-3)
 })
 
-context("multiple terms per factor")
+#context("multiple terms per factor")
 test_that("multiple terms work", {
     fm <- lmer(Reaction ~ Days + (1|Subject)+ (0+Days | Subject), sleepstudy,
                control=lmerControl(optimizer="nloptwrap",

--- a/tests/testthat/test-rank.R
+++ b/tests/testthat/test-rank.R
@@ -1,7 +1,4 @@
-library("testthat")
-library("lme4")
-
-context("testing fixed-effect design matrices for full rank")
+#context("testing fixed-effect design matrices for full rank")
 
 test_that("lmerRank", {
     set.seed(101)

--- a/tests/testthat/test-resids.R
+++ b/tests/testthat/test-resids.R
@@ -1,6 +1,4 @@
-library("testthat")
-library("lme4")
-context("residuals")
+#context("residuals")
 test_that("lmer", {
     C1 <- lmerControl(optimizer="nloptwrap",
                       optCtrl=list(xtol_abs=1e-6, ftol_abs=1e-6))
@@ -28,6 +26,7 @@ test_that("lmer", {
     expect_true(all(is.na(resid(fm1NA_exclude)[na_ind])))
     expect_true(!any(is.na(resid(fm1NA_exclude)[-na_ind])))
 })
+
 test_that("glmer", {
     gm1 <- glmer(incidence/size ~ period + (1|herd), cbpp,
                  family=binomial, weights=size)

--- a/tests/testthat/test-simulate_formula.R
+++ b/tests/testthat/test-simulate_formula.R
@@ -1,6 +1,3 @@
-library("testthat")
-library("lme4")
-
 quietly <- TRUE
 
 ## factory for making methods

--- a/tests/testthat/test-start.R
+++ b/tests/testthat/test-start.R
@@ -1,6 +1,4 @@
-library("testthat")
-library("lme4")
-context("specifying starting values")
+#context("specifying starting values")
 
 ##' Update 'mod', copying .@call and attr(.@frame, "start")  from 'from'
 copysome <- function(mod, from) {

--- a/tests/testthat/test-stepHalving.R
+++ b/tests/testthat/test-stepHalving.R
@@ -1,5 +1,3 @@
-library(lme4)
-library(testthat)
 load(system.file("testdata","survdat_reduced.Rda",package="lme4"))
 
 test_that('Step-halving works properly', {

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -1,10 +1,8 @@
-library("testthat")
 try(detach("package:lmerTest"), silent = TRUE)
-library("lme4")
 
 testLevel <- if (nzchar(s <- Sys.getenv("LME4_TEST_LEVEL"))) as.numeric(s) else 1
 
-context("summarizing/printing models")
+#context("summarizing/printing models")
 test_that("lmer", {
   set.seed(0)
   J <- 8

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,12 +1,9 @@
-library("testthat")
-library("lme4")
-
 ## use old (<=3.5.2) sample() algorithm if necessary
 if ("sample.kind" %in% names(formals(RNGkind))) {
     suppressWarnings(RNGkind("Mersenne-Twister", "Inversion", "Rounding"))
 }
 
-context("Utilities (including *non*-exported ones)")
+#context("Utilities (including *non*-exported ones)")
 
 test_that("namedList", {
     nList <- lme4:::namedList
@@ -41,7 +38,6 @@ test_that("Var-Cov factor conversions", { ## from ../../R/vcconv.R
 })
 
 ## moved to lme4
-
 
 test_that("getData", {
     ## test what happens when wrong version of 'data' is found in environment of formula ...


### PR DESCRIPTION
This pertains to the final comment here: https://github.com/lme4/lme4/issues/774#issuecomment-3133800805 where a test was added to ensure there's a warning message.

And some comments here: https://github.com/lme4/lme4/commit/ecc3f3e3b5996479d6de0b266f1eecb195fec6af#r163044965 where I got rid of all instances of using `library(lme4)` and `library(testthat)`.

I also commented out `context()` as it is now deprecated.
