### PR TITLE
Preventing environment leaks for allFit

### DIFF
--- a/tests/testthat/test-allFit.R
+++ b/tests/testthat/test-allFit.R
@@ -4,12 +4,17 @@ if (testLevel>1) {
   L <- load(system.file("testdata", "lme-tst-fits.rda",
                         package="lme4", mustWork=TRUE))
   
+  had_pars <- exists("pars", envir = globalenv(), inherits = FALSE)
+  had_ctrl <- exists("ctrl", envir = globalenv(), inherits = FALSE)
+  
   gm_all <- allFit(fit_cbpp_1, verbose=TRUE)
   gm_all_nostart <- allFit(fit_cbpp_1, verbose=FALSE, start_from_mle = FALSE)
 
-  test_that("ensuring global environment is not contaminated", {
-    expect_equal(!("pars" %in% ls()), TRUE)
-    expect_equal(!("ctrl" %in% ls()), TRUE)
+  test_that("pars and ctrl did not leak into the environment", {
+    expect_equal(exists("pars", envir = globalenv(), inherits = FALSE), 
+                 had_pars)
+    expect_equal(exists("ctrl", envir = globalenv(), inherits = FALSE), 
+                 had_ctrl)
   })
   
   summary(gm_all)$times[,"elapsed"]
@@ -98,6 +103,7 @@ if (testLevel>1) {
                 cbind(incidence, size - incidence) ~ period + (1 | herd),
                 data = dataset, family = binomial
             )
+            gm1@call$data <- dataset
             allFit(gm1, catch.errs=FALSE)
         }
 
@@ -112,6 +118,5 @@ if (testLevel>1) {
         ##  but close enough ...
         expect_true(all(is.na(v) | v < 12))
     })
-
 
 }  ## testLevel


### PR DESCRIPTION
This pull request pertains to the following issue: https://github.com/lme4/lme4/issues/853

I used Henrik Bengtsson's suggestion for evaluating and assigning `pars` and `ctrl` within a temporary environment to prevent potential issues.

Also, modified some of the tests to ensure there's no future leakage, as well as added a line to one of the existing tests (which caused some errors earlier).