### PR TITLE
Adding conv.nparmax to merControl()

### DIFF
--- a/R/checkConv.R
+++ b/R/checkConv.R
@@ -16,7 +16,9 @@ help_str <- "\n  See ?lme4::convergence and ?lme4::troubleshooting."
 ##'   (length is taken to determine number of RE parameters)
 ##' @param debug useful if some checks are on "ignore", but would "trigger"
 ##' @param nobs the number of observations from the dataset
-checkConv <- function(derivs, coefs, ctrl, lbound, debug = FALSE, nobs = NULL)
+##' @param ndim the number of coefficients (dimension) from the model
+checkConv <- function(derivs, coefs, ctrl, lbound, debug = FALSE, 
+                      nobs = NULL, ndim = NULL)
 {
     res <- list()
     ntheta <- length(lbound)
@@ -48,6 +50,8 @@ checkConv <- function(derivs, coefs, ctrl, lbound, debug = FALSE, nobs = NULL)
     ## bail out
     if (is.null(derivs) || (!is.null(nobs) && nobs >
                             ctrl$check.conv.nobsmax)) return(NULL)
+    if (is.null(derivs) || (!is.null(ndim) && ndim >
+                            ctrl$check.conv.nparmax)) return(NULL)
     
     if (anyNA(derivs$gradient))
         return(list(code = -5L,

--- a/R/checkConv.R
+++ b/R/checkConv.R
@@ -16,7 +16,8 @@ help_str <- "\n  See ?lme4::convergence and ?lme4::troubleshooting."
 ##'   (length is taken to determine number of RE parameters)
 ##' @param debug useful if some checks are on "ignore", but would "trigger"
 ##' @param nobs the number of observations from the dataset
-##' @param ndim the number of coefficients (dimension) from the model
+##' @param ndim the number of dimensions for the variance-covariance matrix 
+##' of random effects
 checkConv <- function(derivs, coefs, ctrl, lbound, debug = FALSE, 
                       nobs = NULL, ndim = NULL)
 {

--- a/R/lmerControl.R
+++ b/R/lmerControl.R
@@ -88,6 +88,7 @@ merControl <-
              check.formula.LHS = "stop",
              ## convergence options
              check.conv.nobsmax = 1e4,
+             check.conv.nparmax = 50,
              check.conv.grad     = .makeCC("warning", tol = 2e-3, relTol = NULL),
              check.conv.singular = .makeCC(action = "message", tol = formals(isSingular)$tol),
              check.conv.hess     = .makeCC(action = "warning", tol = 1e-6),
@@ -152,6 +153,7 @@ merControl <-
                                        check.formula.LHS),
                          checkConv=
                              namedList(check.conv.nobsmax,
+                                       check.conv.nparmax,
                                        check.conv.grad,
                                        check.conv.singular,
                                        check.conv.hess),

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -34,6 +34,10 @@
       \code{[g]lmerControl()}); default threshold is 1e4 observations.
       If desired, derivatives can be calculated (but not checked)
       by explicitly setting \code{calc.derivs} to TRUE.
+      \item similarly, gradient/hessian based check are now skipped
+      for models with high dimensions (number of dimensions greater 
+      than the \code{check.conv.nparmax}) component of
+      \code{[g]lmerControl()}); default threshold is XX observations.
       \item added six publically available datasets: 
       \itemize{
         \item \code{cbpp2} (contagious bovine pleuropneumonia 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -35,9 +35,10 @@
       If desired, derivatives can be calculated (but not checked)
       by explicitly setting \code{calc.derivs} to TRUE.
       \item similarly, gradient/hessian based check are now skipped
-      for models with high dimensions (number of dimensions greater 
-      than the \code{check.conv.nparmax}) component of
-      \code{[g]lmerControl()}); default threshold is XX observations.
+      for models whose the dimensions of the variance-covariance matrix 
+      of random effects is high (number of dimensions greater 
+      than the \code{check.conv.nparmax} component of
+      \code{[g]lmerControl()}); default threshold is 50 observations.
       \item added six publically available datasets: 
       \itemize{
         \item \code{cbpp2} (contagious bovine pleuropneumonia 

--- a/man/checkConv.Rd
+++ b/man/checkConv.Rd
@@ -8,7 +8,7 @@
   see \link{convergence} for a more detailed discussion.
 }
 \usage{
-checkConv(derivs, coefs, ctrl, lbound, debug = FALSE, nobs = NULL)
+checkConv(derivs, coefs, ctrl, lbound, debug = FALSE, nobs = NULL, ndim = NULL)
 }
 
 \arguments{
@@ -24,6 +24,8 @@ checkConv(derivs, coefs, ctrl, lbound, debug = FALSE, nobs = NULL)
     "ignore", but would "trigger"}
   \item{nobs}{number of observations (needed to determine whether to do
   convergence checks for large data)}
+  \item{ndim}{number of dimensions (needed to determine whether to do the
+  gradient/hessian checks for large nonlinear optimization problems)}
 }
 \value{
   A result list containing

--- a/man/checkConv.Rd
+++ b/man/checkConv.Rd
@@ -24,7 +24,8 @@ checkConv(derivs, coefs, ctrl, lbound, debug = FALSE, nobs = NULL, ndim = NULL)
     "ignore", but would "trigger"}
   \item{nobs}{number of observations (needed to determine whether to do
   convergence checks for large data)}
-  \item{ndim}{number of dimensions (needed to determine whether to do the
+  \item{ndim}{number of dimensions for the variance-covariance matrix 
+  of random effects (needed to determine whether to do the
   gradient/hessian checks for large nonlinear optimization problems)}
 }
 \value{

--- a/man/lmerControl.Rd
+++ b/man/lmerControl.Rd
@@ -42,6 +42,7 @@ lmerControl(optimizer = "nloptwrap",% was "Nelder_Mead" till Dec.2013,
     check.formula.LHS = "stop",
     ## convergence checking options
     check.conv.nobsmax  = 1e4,
+    check.conv.nparmax  = 50,
     check.conv.grad     = .makeCC("warning", tol = 2e-3, relTol = NULL),
     check.conv.singular = .makeCC(action = "message", tol = formals(isSingular)$tol),
     check.conv.hess     = .makeCC(action = "warning", tol = 1e-6),
@@ -70,6 +71,7 @@ glmerControl(optimizer = c("bobyqa", "Nelder_Mead"),
     check.formula.LHS = "stop",
     ## convergence checking options
     check.conv.nobsmax  = 1e4, 
+    check.conv.nparmax  = 50,
     check.conv.grad     = .makeCC("warning", tol = 2e-3, relTol = NULL),
     check.conv.singular = .makeCC(action = "message", tol = formals(isSingular)$tol),
     check.conv.hess     = .makeCC(action = "warning", tol = 1e-6),
@@ -132,7 +134,9 @@ nlmerControl(optimizer = "Nelder_Mead", tolPwrss = 1e-10,
     optimization solution? Default NULL value says these derivatives
     should be calculated if and only if
     derivative-based convergence checks
-    are going to be done (i.e. when \code{nobs(model) < check.conv.nobxmax})}
+    are going to be done (i.e. when \code{nobs(model) < check.conv.nobsmax} and
+    \code{ndim(model) < check.conv.nparmax} where \code{ndim} refers to the
+    dimensions of the variance-covariance matrix)}
   \item{use.last.params}{(logical) should the last value of the
     parameters evaluated (\code{TRUE}), rather than the value of the
     parameters corresponding to the minimum deviance, be returned?
@@ -197,6 +201,10 @@ nlmerControl(optimizer = "Nelder_Mead", tolPwrss = 1e-10,
   \item{check.conv.nobsmax}{threshold for the number of observations 
     above which derivative-based convergence checks are skipped.
     (Set this argument to \code{Inf} to  restore previous behaviour
+    of always checking.)}
+  \item{check.conv.nparmax}{threshold for the number of dimensions of the
+    variance/covariance matrix above which derivative-based convergence checks 
+    are skipped. (Set this argument to \code{Inf} to  restore previous behaviour
     of always checking.)}
   \item{check.conv.grad}{rules for checking the gradient of the deviance
     function for convergence.  A list as returned

--- a/tests/testthat/test-lmer.R
+++ b/tests/testthat/test-lmer.R
@@ -412,7 +412,8 @@ test_that("turn off conv checking for nobs > check.conv.nobsmax", {
 test_that("turn off conv checking for npara > check.conv.nparmax", {
   ## This is taken from an example shown here:
   ## https://github.com/lme4/lme4/issues/783#issue-2266130542
-  set.seed(4)
+  ## This particular seed doesn't have singular fit issues
+  set.seed(6)
   
   data <- data.frame(row.names = 1:150)
   data$class <- sample(1:25, 150, replace = TRUE)
@@ -451,10 +452,11 @@ test_that("turn off conv checking for npara > check.conv.nparmax", {
   mod1 <- suppressWarnings(
     lmer(eval~group*emint_n + group*grade_n + (grade_n+emint_n|class), data=data))
   mod2 <- lmer(eval~group*emint_n + group*grade_n + (grade_n+emint_n|class), 
-              control = lmerControl(check.conv.nparmax = 5), data=data)
+              control = lmerControl(optimizer = "bobyqa", 
+                                    check.conv.nparmax = 5), data=data)
 
   ## First should give a warning
   expect_false(is.null(mod1@optinfo$conv$lme4))
   ## Second shouldn't be evaluated
-  expect_null(mod2@optinfo$conv$lme4)
+  expect_true(is.null(mod2@optinfo$conv$lme4))
 })

--- a/tests/testthat/test-lmer.R
+++ b/tests/testthat/test-lmer.R
@@ -458,5 +458,5 @@ test_that("turn off conv checking for npara > check.conv.nparmax", {
   ## First should give a warning
   expect_false(is.null(mod1@optinfo$conv$lme4))
   ## Second shouldn't be evaluated
-  expect_true(is.null(mod2@optinfo$conv$lme4))
+  expect_null(mod2@optinfo$conv$lme4)
 })


### PR DESCRIPTION
Refer to the following comment: https://github.com/lme4/lme4/issues/783#issuecomment-3156476503 

Also added:
- Test to ensure that `conv.nparmax` works
- Updated news and relevant documentation (did run `R CMD check`)

Small concerns:
- Set the default to be `=50`; unsure if this is too large (or too small!)
- The example for the test isn't the most elegant; had a hard time reproducing an issue in a more efficient manner