### PR TITLE
Calculate derivatives even when fit is singular!!

### DIFF
--- a/R/lmer.R
+++ b/R/lmer.R
@@ -50,6 +50,9 @@ lmer <- function(formula, data=NULL, REML = TRUE,
     if (identical(control$optimizer,"none"))
       stop("deprecated use of optimizer=='none'; use NULL instead")
     
+    ## Checks if the user actually enabled calc.derivs
+    force.calc.derivs <- isTRUE(control$calc.derivs)
+    
     calc.derivs <- control$calc.derivs %||% 
       (nrow(lmod$fr) < control$checkConv$check.conv.nobsmax &
        length(s)    < control$checkConv$check.conv.nparmax)
@@ -65,6 +68,7 @@ lmer <- function(formula, data=NULL, REML = TRUE,
                      verbose=verbose,
                      start=start,
                      calc.derivs=calc.derivs,
+                     force.calc.derivs=force.calc.derivs,
                      use.last.params=control$use.last.params)
            }
     cc <- checkConv(attr(opt,"derivs"), opt$par,
@@ -2641,6 +2645,7 @@ getOptfun <- function(optimizer) {
 
 optwrap <- function(optimizer, fn, par, lower = -Inf, upper = Inf,
                     control = list(), adj = FALSE, calc.derivs = TRUE,
+                    force.calc.derivs = FALSE,
                     use.last.params = FALSE,
                     verbose = 0L)
 {
@@ -2725,9 +2730,9 @@ optwrap <- function(optimizer, fn, par, lower = -Inf, upper = Inf,
     }
     ## pp_before <- environment(fn)$pp
     ## save(pp_before,file="pp_before.RData")
-
+    
     singular <- any(opt$par[lower==0] < getSingTol())
-    if (calc.derivs && !singular) {
+    if (force.calc.derivs || (calc.derivs && !singular)){
         if (use.last.params) {
             ## +0 tricks R into doing a deep copy ...
             ## otherwise element of ref class changes!

--- a/tests/testthat/test-lmer.R
+++ b/tests/testthat/test-lmer.R
@@ -477,4 +477,10 @@ test_that("gradient and Hessian checks are skipped when singular fit occurs",{
   expect_null(summary(fm2)$optinfo$derivs$Hessian)
   ## Switching back (in case needed)
   options(lme4.singular.tolerance = 1e-4)
+  
+  ## force calculating the derivatives even if the fit is singular
+  fm2 <- lmer(y ~ x + (1 | group), 
+              control = lmerControl(calc.derivs = TRUE), data = dat)
+  expect_false(is.null(summary(fm2)$optinfo$derivs))
 })
+


### PR DESCRIPTION
Dealing with this issue: https://github.com/lme4/lme4/issues/883

Not a bad fix; essentially, if the user explicitly wrote `calc.derivs = TRUE` then it will always compute the derivatives, even with a singular fit.

Also added a test associated with this; but feel free to see how it works yourself:

```{r}
library(lme4)

set.seed(1)
group <- factor(rep(1:3, each = 20))
b <- rnorm(3, mean = 0, sd = 0.01)
x <- rnorm(60)
y <- x + b[group] + rnorm(60, sd = 1)
dat <- data.frame(y, x, group)

fm1 <- lmer(y ~ x + (1 | group), data = dat)

summary(fm1)$optinfo$derivs
## idea: if user forced calc.derivs = TRUE then...

fm1 <- lmer(y ~ x + (1 | group), 
            control = lmerControl(calc.derivs = TRUE), data = dat)

summary(fm1)$optinfo$derivs
```