### PR TITLE
Clean up and robustify parallelization code

### DIFF
--- a/R/allFit.R
+++ b/R/allFit.R
@@ -113,9 +113,9 @@ allFit <- function(object, meth.tab = NULL,
 	      is.character(method    <- meth.tab[,"method"]))
 
     parallel <- match.arg(parallel)
-    do_parallel <- have_mc <- have_snow <- NULL # "-Wall"
-    eval(initialize.parallel) # (parallel, ncpus)   --> ./utilities.R
-    ## |--> (do_parallel, have_mc, have_snow)
+
+    # (parallel, ncpus, cl) -> (parallel)
+    eval(initialize.parallel)
 
     fit.names <- gsub("\\.$", "", paste(optimizer, method, sep="."))
     ffun <- local({
@@ -217,28 +217,20 @@ allFit <- function(object, meth.tab = NULL,
     })
 
     seq_fit <- seq_along(fit.names)
-    res <- if (do_parallel) {
-               if (have_mc) {
-                   parallel::mclapply(seq_fit,
-                                      ffun, mc.cores = ncpus)
-               } else if(have_snow) {
-                   if(is.null(cl)) {
-                       cl <- parallel::makeCluster(ncpus)
-                       ## consider exporting data/package ?
-                       ## parallel::clusterEvalQ(cl,library("lme4"))
-                       ## try to get data and export it?
-                       ## parallel::clusterExport(cl,??)
-                       res <- parallel::parLapply(cl, seq_fit, ffun)
-                       parallel::stopCluster(cl)
-                       res
-                   } else parallel::parLapply(cl, seq_fit, ffun)
-               } else {
-                   warning("'do_parallel' is true, but 'have_mc' and 'have_snow' are not.  Should not happen!")
-                   ## or stop()  or  we could silently use lapply(..)
-                   setNames(as.list(fit.names), fit.names)
-               }
-           } else
-               lapply(seq_fit, ffun)
+    res <- if (parallel == "multicore") {
+         parallel::mclapply(seq_fit, ffun, mc.cores = ncpus)
+    } else if(parallel == "snow") {
+        if (is.null(cl)) {
+            cl <- parallel::makeCluster(ncpus)
+            on.exit(parallel::stopCluster(cl))
+            ## consider exporting data/package ?
+            ## parallel::clusterEvalQ(cl,library("lme4"))
+            ## try to get data and export it?
+            ## parallel::clusterExport(cl,??)
+        }
+        parallel::parLapply(cl, seq_fit, ffun)
+    } else
+        lapply(seq_fit, ffun)
 
     names(res) <- fit.names
     structure(res, class = "allFit", fit = object, sessionInfo =  sessionInfo(),

--- a/R/bootMer.R
+++ b/R/bootMer.R
@@ -43,10 +43,13 @@ bootMer <- function(x, FUN, nsim = 1, seed = NULL,
         pb <- do.call(pbfun,PBargs)
     }
 
-    do_parallel <- have_mc <- have_snow <- NULL # '-Wall', set here:
+
+    parallel <- match.arg(parallel)
+
+    # (parallel, ncpus, cl) -> (parallel)
     eval(initialize.parallel)
 
-    if (do_parallel && .progress != "none")
+    if (parallel != "no" && .progress != "none")
         message("progress bar disabled for parallel operations")
 
     FUN <- match.fun(FUN)
@@ -101,7 +104,7 @@ bootMer <- function(x, FUN, nsim = 1, seed = NULL,
       x
       ss
       verbose
-      do_parallel
+      parallel
       control
       length.t0 <- length(t0)
       f1 <- factory(function(i) FUN(refit(x, ss[[i]],
@@ -109,27 +112,24 @@ bootMer <- function(x, FUN, nsim = 1, seed = NULL,
       function(i) {
           ret <- f1(i)
           if (verbose) { cat(sprintf("%5d :",i)); str(ret) }
-          if (!do_parallel && .progress!="none") { setpbfun(pb,i/nsim) }
+          if (parallel == "no" && .progress!="none") { setpbfun(pb,i/nsim) }
           ret
       }})
 
     simvec <- seq_len(nsim)
-    res <- if (do_parallel) {
-        if (have_mc) {
-            parallel::mclapply(simvec, ffun, mc.cores = ncpus)
-        } else if (have_snow) {
-            if (is.null(cl)) {
-                cl <- parallel::makeCluster(ncpus)
-                ## explicit export of the lme4 namespace since most FUNs will probably
-                ## use some of them
-                parallel::clusterExport(cl, varlist=getNamespaceExports("lme4"))
-                if(RNGkind()[1L] == "L'Ecuyer-CMRG")
-                    parallel::clusterSetRNGStream(cl)
-                res <- parallel::parLapply(cl, simvec, ffun)
-                parallel::stopCluster(cl)
-                res
-            } else parallel::parLapply(cl, simvec, ffun)
+    res <- if (parallel == "multicore") {
+        parallel::mclapply(simvec, ffun, mc.cores = ncpus)
+    } else if (parallel == "snow") {
+        if (is.null(cl)) {
+            cl <- parallel::makeCluster(ncpus)
+            on.exit(parallel::stopCluster(cl))
+            ## explicit export of the lme4 namespace since most FUNs will probably
+            ## use some of them
+            parallel::clusterExport(cl, varlist=getNamespaceExports("lme4"))
+            if(RNGkind()[1L] == "L'Ecuyer-CMRG")
+                parallel::clusterSetRNGStream(cl)
         }
+        parallel::parLapply(cl, simvec, ffun)
     } else lapply(simvec, ffun)
 
     t.star <- do.call(cbind,res)

--- a/R/profile.R
+++ b/R/profile.R
@@ -44,9 +44,11 @@ profile.merMod <- function(fitted,
     ## FIXME: allow for failure of bounds (non-pos-definite correlation matrices) when >1 cor parameter
 
     prof.scale <- match.arg(prof.scale)
-    parallel   <- match.arg(parallel)
-    do_parallel <- have_mc <- have_snow <- NULL # "-Wall" are set here:
-    eval(initialize.parallel)# (parallel, ncpus)
+
+    parallel <- match.arg(parallel)
+
+    # (parallel, ncpus, cl) -> (parallel)
+    eval(initialize.parallel)
 
     if (is.null(optimizer)) optimizer <- fitted@optinfo$optimizer
     ## hack: doesn't work to set bobyqa parameters to *ending* values stored
@@ -310,22 +312,19 @@ profile.merMod <- function(fitted,
     }}) ## FUN()
 
     ## copied from bootMer: DRY!
-    L <- if (do_parallel) {
-        if (have_mc) {
-            parallel::mclapply(seqnvp, FUN, mc.cores = ncpus)
-        } else if (have_snow) {
-            if (is.null(cl)) {
-                cl <- parallel::makeCluster(ncpus)
-                ## explicit export of the lme4 namespace since most FUNs will probably
-                ## use some of them
-                parallel::clusterExport(cl, varlist=getNamespaceExports("lme4"))
-                if(RNGkind()[1L] == "L'Ecuyer-CMRG")
-                    parallel::clusterSetRNGStream(cl)
-                pres <- parallel::parLapply(cl, seqnvp, FUN)
-                parallel::stopCluster(cl)
-                pres
-            } else parallel::parLapply(cl, seqnvp, FUN)
+    L <- if (parallel == "multicore") {
+        parallel::mclapply(seqnvp, FUN, mc.cores = ncpus)
+    } else if (parallel == "snow") {
+        if (is.null(cl)) {
+            cl <- parallel::makeCluster(ncpus)
+            on.exit(parallel::stopCluster(cl))
+            ## explicit export of the lme4 namespace since most FUNs will probably
+            ## use some of them
+            parallel::clusterExport(cl, varlist=getNamespaceExports("lme4"))
+            if(RNGkind()[1L] == "L'Ecuyer-CMRG")
+                parallel::clusterSetRNGStream(cl)
         }
+        parallel::parLapply(cl, seqnvp, FUN)
     } else lapply(seqnvp, FUN)
     nn <- names(opt[seqnvp])
     ans <-    setNames(lapply(L, `[[`,  "bres"), nn)


### PR DESCRIPTION
* Drop use of `do_parallel`, `have_mc` and `have_snow`; rely on `parallel` instead

* Validate also arguments `cl` and `ncpus`

* Use `on.exit(parallel::stopCluster(cl))` everywhere. This avoids leaving stray clusters behind in case of run-time errors

This also prepares for future additions, e.g. `parallel = "future"` (#928)