### PR TITLE
Fix glmer fails on Gamma problems with small shape parameter

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -243,6 +243,13 @@ mkRespMod <- function(fr, REML=NULL, family = NULL, nlenv = NULL, nlmod = NULL, 
         ## see ll 180-182 of src/library/stats/R/glm.R
         ## https://github.com/wch/r-source/search?utf8=%E2%9C%93&q=mukeep
         if (!is.null(mustart_update)) rho$mustart <- mustart_update
+        ## For Gamma family, replace mustart (= y) with mean(y) to improve PIRLS stability.
+        ## Using mustart = y causes PIRLS divergence for small shape parameters (e.g. shape < 0.2)
+        ## because E[log(y)] << log(E[y]) (Jensen's inequality): the OLS fit of log(y) ~ X gives
+        ## coefficients implying exp(fitted) << y, leading to explosive working responses.
+        else if (family$family == "Gamma" && is.null(etastart_update) && length(y) > 0) {
+            rho$mustart[] <- mean(rho$mustart)
+        }
         ## family$initialize <- NULL     # remove clutter from str output
         ll <- as.list(rho)
         ans <- do.call(new, c(list(Class="glmResp", family=family),

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -245,8 +245,8 @@ mkRespMod <- function(fr, REML=NULL, family = NULL, nlenv = NULL, nlmod = NULL, 
         if (!is.null(mustart_update)) rho$mustart <- mustart_update
         ## For Gamma family, replace mustart (= y) with mean(y) to improve PIRLS stability.
         ## Using mustart = y causes PIRLS divergence for small shape parameters (e.g. shape < 0.2)
-        ## because E[log(y)] << log(E[y]) (Jensen's inequality): the OLS fit of log(y) ~ X gives
-        ## coefficients implying exp(fitted) << y, leading to explosive working responses.
+        ## because E[log(y)] <= log(E[y]) (Jensen's inequality): the OLS fit of log(y) ~ X gives
+        ## coefficients implying exp(fitted) <= y (optimizes on wrong target)
         else if (family$family == "Gamma" && is.null(etastart_update) && length(y) > 0) {
             rho$mustart[] <- mean(rho$mustart)
         }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -7,6 +7,9 @@
 \section{CHANGES IN VERSION 2.0-2}{
   \subsection{BUG FIXES}{
     \itemize{
+      \item fixed the case where a Gamma GLMM doesn't perform well for 
+      a small shape parameter by changing the initial starting 
+      point of the optimizer for Gamma families (GH #290)
       \item fixed parameter-counting bug for structured covariance
       matrices (internal \code{npar.merMod} function, results exposed in
       \code{logLik}, \code{anova}, \code{df.residual} ...) (GH #943,

--- a/tests/testthat/test-glmFamily.R
+++ b/tests/testthat/test-glmFamily.R
@@ -155,6 +155,24 @@ test_that("estimated Gamma shape is correct", {
   expect_equal(shape_val, 1.94511502080571, tolerance = 1e-6)
 })
 
+test_that("glmer works for Gamma with small shape parameter (issue #701)", {
+  ## shape=0.1 previously caused PIRLS divergence due to E[log(y)] << log(E[y])
+  shape_param <- 0.1
+  set.seed(1001)
+  d <- expand.grid(block = LETTERS[1:26], rep = 1:100, KEEP.OUT.ATTRS = FALSE)
+  d$x <- runif(nrow(d))
+  reff_f <- rnorm(length(levels(d$block)), sd = 1)
+  d$eta <- 4 + 3 * d$x + reff_f[d$block]
+  d$y <- rgamma(nrow(d), scale = exp(d$eta) / shape_param, shape = shape_param)
+  ## glmer should succeed (previously failed with PIRLS convergence error)
+  fit <- suppressWarnings(
+    glmer(y ~ x + (1|block), data = d, family = Gamma(link = "log"))
+  )
+  expect_s4_class(fit, "merMod")
+  ## fixed effects should be close to true values (intercept=4, slope=3)
+  expect_equal(unname(fixef(fit)), c(4, 3), tolerance = 0.5)
+})
+
 simfun_invgauss <- function(ngrp = 50, nrep = 500, lambda = 1, 
                             use_simulate = FALSE, seed = NULL) {
   if (!is.null(seed)) set.seed(seed)

--- a/tests/testthat/test-glmFamily.R
+++ b/tests/testthat/test-glmFamily.R
@@ -155,22 +155,28 @@ test_that("estimated Gamma shape is correct", {
   expect_equal(shape_val, 1.94511502080571, tolerance = 1e-6)
 })
 
-test_that("glmer works for Gamma with small shape parameter (issue #701)", {
-  ## shape=0.1 previously caused PIRLS divergence due to E[log(y)] << log(E[y])
-  shape_param <- 0.1
-  set.seed(1001)
-  d <- expand.grid(block = LETTERS[1:26], rep = 1:100, KEEP.OUT.ATTRS = FALSE)
-  d$x <- runif(nrow(d))
-  reff_f <- rnorm(length(levels(d$block)), sd = 1)
-  d$eta <- 4 + 3 * d$x + reff_f[d$block]
-  d$y <- rgamma(nrow(d), scale = exp(d$eta) / shape_param, shape = shape_param)
-  ## glmer should succeed (previously failed with PIRLS convergence error)
-  fit <- suppressWarnings(
-    glmer(y ~ x + (1|block), data = d, family = Gamma(link = "log"))
-  )
-  expect_s4_class(fit, "merMod")
-  ## fixed effects should be close to true values (intercept=4, slope=3)
-  expect_equal(unname(fixef(fit)), c(4, 3), tolerance = 0.5)
+test_that("glmer works for Gamma with small shape parameter", {
+  ## shape=0.1 previously caused PIRLS divergence
+  ## we are also testing for different values of Gamma to be safe
+  shape_vec <- c(0.1,0.5,1,2,5)
+  set.seed(123)
+  for(shape_param in shape_vec){
+    d <- expand.grid(block = LETTERS[1:26], rep = 1:100, KEEP.OUT.ATTRS = FALSE)
+    d$x <- runif(nrow(d))
+    reff_f <- rnorm(length(levels(d$block)), sd = 1)
+    d$eta <- 4 + 3 * d$x + reff_f[d$block]
+    d$y <- rgamma(nrow(d), scale = exp(d$eta) / shape_param, shape = shape_param)
+
+    fit <- suppressWarnings(
+      glmer(y ~ x + (1|block), data = d, family = Gamma(link = "log"))
+    )
+    expect_s4_class(fit, "merMod")
+    ## testing for the shape parameter.
+    expect_equal(1/sigma(fit)^2, shape_param, tolerance = 0.1)
+    ## fixed effects should be close to true values (intercept=4, slope=3)
+    expect_equal(unname(fixef(fit)), c(4, 3), tolerance = 0.5)
+    print(unname(fixef(fit)))
+  }
 })
 
 simfun_invgauss <- function(ngrp = 50, nrep = 500, lambda = 1, 


### PR DESCRIPTION
Longstanding issue: https://github.com/lme4/lme4/issues/290 

Got copilot to fix this issue and added some appropriate tests.

Copilot's solution: for the Gamma family, replace `mustart = y` with `mustart = mean(y)` to stabilize PIRLS initialization.

Rationale: when `mustart = y`, IF the link function is `log`, the $$\hat{\beta}$$ coefficients are estimated by minimizing the sum of squared errors in log-space. So, $$X \hat{\beta}$$ is close to $$\log(y)$$.

The resulting coefficients satisfy $$X \hat{\beta} ≈ \mathbb{E}[\log(y)]$$.

An **alternative** estimate would be to instead make $\exp(X \hat{\beta})$ close to $y$ which would then require $$X \hat{\beta} = \log(\mathbb{E}[y])$$.

Jensen's inequality shows that it's possible both of the above possible estimates vary significantly: $$\mathbb{E}[\log(y)] \leq \log(\mathbb{E}[y])$$. It appears that for a small shape parameter, we have that $$\mathbb{E}[\log(y)]$$ is significantly smaller than $$\log(\mathbb{E}[y])$$. However, $$\log(\mathbb{E}[y])$$ appears to perform quite well, suggesting the small estimate of $$\mathbb{E}[\log(y)]$$ is what makes it worse.

Note: the solution does not use `log()`. The above is a rationale for the `Gamma(link = "log")` family and link function as to why those examples work, and why using an alternative estimate will improve the estimate.

It appears that the alternative starting point (i.e., taking the mean of `y` as the starting point instead of just `y`) is sufficient and works well.