### PR TITLE
Improve documentation for start= argument of (g)lmer

### DIFF
--- a/man/glmer.Rd
+++ b/man/glmer.Rd
@@ -43,29 +43,10 @@ glmer(formula, data = NULL, family = gaussian
     optimizer to be used and parameters to be passed through to the
     nonlinear optimizer, see the \code{*lmerControl} documentation for
     details.}
-  \item{start}{a numeric vector or a named \link{list} with optional
-    components, one named \code{par} or \code{theta} and another named
-    \code{fixef} or \code{beta}, giving starting values for covariance
-    parameters and fixed effect coefficients, respectively.  Numeric
-    \code{start} initializes only the covariance parameters (i.e., it is
-    equivalent to \code{list(par = start)} and leaves fixed effects at
-    their default start unless \code{fixef}/\code{beta} is supplied in a
-    list).  The elements of this numeric vector are interpreted in the
-    same order as \code{par}/\code{theta} (concatenated across random-
-    effect terms).
-    For each term, \code{par}/\code{theta} specifies the \emph{relative}
-    covariance as follows: for unstructured (\code{us}) terms, entries
-    are the lower-triangular elements of the relative Cholesky factor
-    \eqn{\Lambda_\theta}; for diagonal (\code{diag}) terms, entries are
-    the standard deviation parameter(s); for compound-symmetry
-    (\code{cs}) and AR(1) (\code{ar1}) terms, entries are the standard
-    deviation parameter(s) followed by the correlation parameter
-    \eqn{\rho} (on its natural bounded scale).  For structured terms, the
-    supplied \code{par} values are internally mapped by \code{getTheta()}
-    to the corresponding lower-triangular \eqn{\Lambda_\theta} entries
-    used by the optimizer.
-    If two optimization steps are
-    performed, as by default, then the first step uses starting values
+  \item{start}{See the "start" argument of \code{\link{lmer}} for
+    details. If two optimization steps are
+    performed for a GLMM, as by default (i.e. one with \code{nAGQ=0} and
+    a second with \code{nAGQ} > 0), then the first step uses starting values
     \code{par} and the second step uses starting values
     \code{c(newpar, fixef)}, where \code{newpar} is the optimum obtained
     in the first step.  See \code{\link{modular}} for details about

--- a/man/glmer.Rd
+++ b/man/glmer.Rd
@@ -50,17 +50,21 @@ glmer(formula, data = NULL, family = gaussian
     \code{start} initializes only the covariance parameters (i.e., it is
     equivalent to \code{list(par = start)} and leaves fixed effects at
     their default start unless \code{fixef}/\code{beta} is supplied in a
-    list). The elements of this numeric vector are interpreted in the
-    same order as \code{par}/\code{theta}.  The
-    covariance-parameter vector (\code{par}/\code{theta}) is interpreted
-    according to each random-effect covariance structure. For
-    unstructured terms, it is the unique non-zero elements of the lower
-    triangle of the Cholesky factor of the \emph{relative} covariance
-    matrix. For structured terms (\code{diag}, \code{cs}, \code{ar1}),
-    it is the parameter vector for that structure (typically one or more
-    standard deviations, plus correlation parameter(s) where
-    applicable), which is mapped internally to the Cholesky scale. See
-    also \code{\link{simulate.merMod}} (\code{newparams}). By default,
+    list).  The elements of this numeric vector are interpreted in the
+    same order as \code{par}/\code{theta} (concatenated across random-
+    effect terms).
+    For each term, \code{par}/\code{theta} specifies the \emph{relative}
+    covariance as follows: for unstructured (\code{us}) terms, entries
+    are the lower-triangular elements of the relative Cholesky factor
+    \eqn{\Lambda_\theta}; for diagonal (\code{diag}) terms, entries are
+    the standard deviation parameter(s); for compound-symmetry
+    (\code{cs}) and AR(1) (\code{ar1}) terms, entries are the standard
+    deviation parameter(s) followed by the correlation parameter
+    \eqn{\rho} (on its natural bounded scale).  For structured terms, the
+    supplied \code{par} values are internally mapped by \code{getTheta()}
+    to the corresponding lower-triangular \eqn{\Lambda_\theta} entries
+    used by the optimizer.
+    See also \code{\link{simulate.merMod}} (\code{newparams}). By default,
     all relative covariance matrices are identity matrices and all fixed
     effect coefficients are zero.  If two optimization steps are
     performed, as by default, then the first step uses starting values

--- a/man/glmer.Rd
+++ b/man/glmer.Rd
@@ -47,7 +47,11 @@ glmer(formula, data = NULL, family = gaussian
     components, one named \code{par} or \code{theta} and another named
     \code{fixef} or \code{beta}, giving starting values for covariance
     parameters and fixed effect coefficients, respectively.  Numeric
-    \code{start} is equivalent to \code{list(par = start)}.  The
+    \code{start} initializes only the covariance parameters (i.e., it is
+    equivalent to \code{list(par = start)} and leaves fixed effects at
+    their default start unless \code{fixef}/\code{beta} is supplied in a
+    list). The elements of this numeric vector are interpreted in the
+    same order as \code{par}/\code{theta}.  The
     covariance-parameter vector (\code{par}/\code{theta}) is interpreted
     according to each random-effect covariance structure. For
     unstructured terms, it is the unique non-zero elements of the lower

--- a/man/glmer.Rd
+++ b/man/glmer.Rd
@@ -47,15 +47,20 @@ glmer(formula, data = NULL, family = gaussian
     components, one named \code{par} or \code{theta} and another named
     \code{fixef} or \code{beta}, giving starting values for covariance
     parameters and fixed effect coefficients, respectively.  Numeric
-    \code{start} is equivalent to \code{list(par = start)}.  For
-    unstructured covariance matrices, \code{theta} stores the unique
-    non-zero elements of the lower triangle of the Cholesky factor of
-    the \emph{relative} covariance matrix (see also
-    \code{\link{simulate.merMod}}, argument \code{newparams}).  By
-    default, all relative covariance matrices are identity matrices and
-    all fixed effect coefficients are zero.  If two optimization steps
-    are performed, as by default, then the first step uses starting
-    values \code{par} and the second step uses starting values
+    \code{start} is equivalent to \code{list(par = start)}.  The
+    covariance-parameter vector (\code{par}/\code{theta}) is interpreted
+    according to each random-effect covariance structure. For
+    unstructured terms, it is the unique non-zero elements of the lower
+    triangle of the Cholesky factor of the \emph{relative} covariance
+    matrix. For structured terms (\code{diag}, \code{cs}, \code{ar1}),
+    it is the parameter vector for that structure (typically one or more
+    standard deviations, plus correlation parameter(s) where
+    applicable), which is mapped internally to the Cholesky scale. See
+    also \code{\link{simulate.merMod}} (\code{newparams}). By default,
+    all relative covariance matrices are identity matrices and all fixed
+    effect coefficients are zero.  If two optimization steps are
+    performed, as by default, then the first step uses starting values
+    \code{par} and the second step uses starting values
     \code{c(newpar, fixef)}, where \code{newpar} is the optimum obtained
     in the first step.  See \code{\link{modular}} for details about
     finer control of optimization.}

--- a/man/glmer.Rd
+++ b/man/glmer.Rd
@@ -47,9 +47,11 @@ glmer(formula, data = NULL, family = gaussian
     components, one named \code{par} or \code{theta} and another named
     \code{fixef} or \code{beta}, giving starting values for covariance
     parameters and fixed effect coefficients, respectively.  Numeric
-    \code{start} is equivalent to \code{list(par = start)}.  Parameters
-    corresponding to unstructured covariance matrices are on the scale
-    of the Cholesky factor of the relative covariance matrix.  By
+    \code{start} is equivalent to \code{list(par = start)}.  For
+    unstructured covariance matrices, \code{theta} stores the unique
+    non-zero elements of the lower triangle of the Cholesky factor of
+    the \emph{relative} covariance matrix (see also
+    \code{\link{simulate.merMod}}, argument \code{newparams}).  By
     default, all relative covariance matrices are identity matrices and
     all fixed effect coefficients are zero.  If two optimization steps
     are performed, as by default, then the first step uses starting
@@ -196,4 +198,3 @@ if (require("HSAUR3")) {
 }
 }
 \keyword{models}
-

--- a/man/glmer.Rd
+++ b/man/glmer.Rd
@@ -64,9 +64,7 @@ glmer(formula, data = NULL, family = gaussian
     supplied \code{par} values are internally mapped by \code{getTheta()}
     to the corresponding lower-triangular \eqn{\Lambda_\theta} entries
     used by the optimizer.
-    See also \code{\link{simulate.merMod}} (\code{newparams}). By default,
-    all relative covariance matrices are identity matrices and all fixed
-    effect coefficients are zero.  If two optimization steps are
+    If two optimization steps are
     performed, as by default, then the first step uses starting values
     \code{par} and the second step uses starting values
     \code{c(newpar, fixef)}, where \code{newpar} is the optimum obtained

--- a/man/lmer.Rd
+++ b/man/lmer.Rd
@@ -73,10 +73,12 @@ lmer(formula, data = NULL, REML = TRUE, control = lmerControl(),
   \item{start}{a numeric vector or a named \link{list} with one optional
     component named \code{par} or \code{theta}, giving starting values
     for covariance parameters.  Numeric \code{start} is equivalent to
-    \code{list(par = start)}.  Parameters corresponding to unstructured
-    covariance matrices are on the scale of the Cholesky factor of the
-    relative covariance matrix.  By default, all relative covariance
-    matrices are identity matrices.}
+    \code{list(par = start)}.  For unstructured covariance matrices,
+    \code{theta} stores the unique non-zero elements of the lower
+    triangle of the Cholesky factor of the \emph{relative} covariance
+    matrix (see also \code{\link{simulate.merMod}}, argument
+    \code{newparams}).  By default, all relative covariance matrices are
+    identity matrices.}
 
   \item{verbose}{integer scalar.  If \code{> 0} verbose output is
     generated during the optimization of the parameter estimates.  If

--- a/man/lmer.Rd
+++ b/man/lmer.Rd
@@ -70,24 +70,44 @@ lmer(formula, data = NULL, REML = TRUE, control = lmerControl(),
     nonlinear optimizer, see the \code{*lmerControl} documentation for
     details.}
 
-  \item{start}{a numeric vector or a named \link{list} with one optional
-    component named \code{par} or \code{theta}, giving starting values
-    for covariance parameters.  Numeric \code{start} initializes only the
-    covariance parameters (i.e., it is equivalent to
-    \code{list(par = start)}).  The elements of this numeric vector are
-    interpreted in the same order as \code{par}/\code{theta}
-    (concatenated across random-effect terms).
+  \item{start}{a numeric vector or a named list with optional
+    components, one named \code{par} or \code{theta} and another named
+    \code{fixef} or \code{beta}, giving starting values for covariance
+    parameters and fixed effect coefficients, respectively.
+    Specifying \code{start} as a numeric vector initializes only
+    the covariance parameters (i.e., it is equivalent to \code{list(par
+      = start)},
+    leaving fixed effect parameters at their default starting values
+    (i.e., all zero)).
     For each term, \code{par}/\code{theta} specifies the \emph{relative}
-    covariance as follows: for unstructured (\code{us}) terms, entries
+    covariances of random effects terms,  as follows:
+    \itemize{
+      \item for unstructured (\code{us}) terms, entries
     are the lower-triangular elements of the relative Cholesky factor
-    \eqn{\Lambda_\theta}; for diagonal (\code{diag}) terms, entries are
-    the standard deviation parameter(s); for compound-symmetry
+    \eqn{\Lambda_\theta};
+    \item for diagonal (\code{diag}) terms, entries are
+    the standard deviation parameter(s);
+    \item for compound-symmetry
     (\code{cs}) and AR(1) (\code{ar1}) terms, entries are the standard
     deviation parameter(s) followed by the correlation parameter
-    \eqn{\rho} (on its natural bounded scale).  For structured terms, the
-    supplied \code{par} values are internally mapped by \code{getTheta()}
-    to the corresponding lower-triangular \eqn{\Lambda_\theta} entries
-    used by the optimizer.}
+    \eqn{\rho} (specified on the [0,1] scale).
+  }
+  See the \href{../doc/covariance_structures.html}{covariance structures
+    vignette} for more detail on covariance matrix parameterizations.
+  
+  The parameters for all random-effect terms are concatenated in the
+  starting parameter vector,
+  in the order specified by the \emph{internal} ordering of the terms.
+  This matches the order in which the terms are returned in \code{VarCorr()},
+  but may not match the order in which the terms are specified in the
+  formula; as noted in the \href{../doc/lmer.pdf}{lmer vignette},
+  random effect terms are
+  stored in decreasing order of the number of levels of the grouping variable.
+  
+  For structured terms, the
+  supplied \code{par} values are internally mapped by \code{getTheta()}
+  to the corresponding lower-triangular \eqn{\Lambda_\theta}{Lambda[theta]} entries
+  used by the optimizer.}
 
   \item{verbose}{integer scalar.  If \code{> 0} verbose output is
     generated during the optimization of the parameter estimates.  If

--- a/man/lmer.Rd
+++ b/man/lmer.Rd
@@ -73,12 +73,17 @@ lmer(formula, data = NULL, REML = TRUE, control = lmerControl(),
   \item{start}{a numeric vector or a named \link{list} with one optional
     component named \code{par} or \code{theta}, giving starting values
     for covariance parameters.  Numeric \code{start} is equivalent to
-    \code{list(par = start)}.  For unstructured covariance matrices,
-    \code{theta} stores the unique non-zero elements of the lower
-    triangle of the Cholesky factor of the \emph{relative} covariance
-    matrix (see also \code{\link{simulate.merMod}}, argument
-    \code{newparams}).  By default, all relative covariance matrices are
-    identity matrices.}
+    \code{list(par = start)}.  The covariance-parameter vector
+    (\code{par}/\code{theta}) is interpreted according to each
+    random-effect covariance structure. For unstructured terms, it is
+    the unique non-zero elements of the lower triangle of the Cholesky
+    factor of the \emph{relative} covariance matrix. For structured
+    terms (\code{diag}, \code{cs}, \code{ar1}), it is the parameter
+    vector for that structure (typically one or more standard
+    deviations, plus correlation parameter(s) where applicable), which
+    is mapped internally to the Cholesky scale. See also
+    \code{\link{simulate.merMod}} (\code{newparams}). By default, all
+    relative covariance matrices are identity matrices.}
 
   \item{verbose}{integer scalar.  If \code{> 0} verbose output is
     generated during the optimization of the parameter estimates.  If

--- a/man/lmer.Rd
+++ b/man/lmer.Rd
@@ -72,8 +72,11 @@ lmer(formula, data = NULL, REML = TRUE, control = lmerControl(),
 
   \item{start}{a numeric vector or a named \link{list} with one optional
     component named \code{par} or \code{theta}, giving starting values
-    for covariance parameters.  Numeric \code{start} is equivalent to
-    \code{list(par = start)}.  The covariance-parameter vector
+    for covariance parameters.  Numeric \code{start} initializes only the
+    covariance parameters (i.e., it is equivalent to
+    \code{list(par = start)}). The elements of this numeric vector are
+    interpreted in the same order as \code{par}/\code{theta}.  The
+    covariance-parameter vector
     (\code{par}/\code{theta}) is interpreted according to each
     random-effect covariance structure. For unstructured terms, it is
     the unique non-zero elements of the lower triangle of the Cholesky

--- a/man/lmer.Rd
+++ b/man/lmer.Rd
@@ -74,17 +74,21 @@ lmer(formula, data = NULL, REML = TRUE, control = lmerControl(),
     component named \code{par} or \code{theta}, giving starting values
     for covariance parameters.  Numeric \code{start} initializes only the
     covariance parameters (i.e., it is equivalent to
-    \code{list(par = start)}). The elements of this numeric vector are
-    interpreted in the same order as \code{par}/\code{theta}.  The
-    covariance-parameter vector
-    (\code{par}/\code{theta}) is interpreted according to each
-    random-effect covariance structure. For unstructured terms, it is
-    the unique non-zero elements of the lower triangle of the Cholesky
-    factor of the \emph{relative} covariance matrix. For structured
-    terms (\code{diag}, \code{cs}, \code{ar1}), it is the parameter
-    vector for that structure (typically one or more standard
-    deviations, plus correlation parameter(s) where applicable), which
-    is mapped internally to the Cholesky scale. See also
+    \code{list(par = start)}).  The elements of this numeric vector are
+    interpreted in the same order as \code{par}/\code{theta}
+    (concatenated across random-effect terms).
+    For each term, \code{par}/\code{theta} specifies the \emph{relative}
+    covariance as follows: for unstructured (\code{us}) terms, entries
+    are the lower-triangular elements of the relative Cholesky factor
+    \eqn{\Lambda_\theta}; for diagonal (\code{diag}) terms, entries are
+    the standard deviation parameter(s); for compound-symmetry
+    (\code{cs}) and AR(1) (\code{ar1}) terms, entries are the standard
+    deviation parameter(s) followed by the correlation parameter
+    \eqn{\rho} (on its natural bounded scale).  For structured terms, the
+    supplied \code{par} values are internally mapped by \code{getTheta()}
+    to the corresponding lower-triangular \eqn{\Lambda_\theta} entries
+    used by the optimizer.
+    See also
     \code{\link{simulate.merMod}} (\code{newparams}). By default, all
     relative covariance matrices are identity matrices.}
 

--- a/man/lmer.Rd
+++ b/man/lmer.Rd
@@ -87,10 +87,7 @@ lmer(formula, data = NULL, REML = TRUE, control = lmerControl(),
     \eqn{\rho} (on its natural bounded scale).  For structured terms, the
     supplied \code{par} values are internally mapped by \code{getTheta()}
     to the corresponding lower-triangular \eqn{\Lambda_\theta} entries
-    used by the optimizer.
-    See also
-    \code{\link{simulate.merMod}} (\code{newparams}). By default, all
-    relative covariance matrices are identity matrices.}
+    used by the optimizer.}
 
   \item{verbose}{integer scalar.  If \code{> 0} verbose output is
     generated during the optimization of the parameter estimates.  If

--- a/man/salamander.Rd
+++ b/man/salamander.Rd
@@ -36,14 +36,14 @@
   }
 }
 \details{
-  In this example, every variable is either binary or a factor.  However, 
+  Every variable in this data set is either binary or a factor.  However, 
   most of the variables in this data set are treated like a numerical variable
   (i.e., \code{Experiment, Male, Female, Mate}), so we suggest turning them
   into factor variables before use. As outlined in McCullagh and Nelder (1989): 
   This experiment, conducted by S. Arnold and P. Verrell at the University of 
   Chicago, investigated whether geographically isolated populations of mountain 
   dusky salamanders would interbreed. The goal was to see the difference in 
-  mating frquencies between the \code{RW} crosses compared to the \code{WR}
+  mating frequencies between the \code{RW} crosses compared to the \code{WR}
   crosses. Because each salamander was involved in multiple mating trials with 
   different partners, the observations are not independent. Therefore, we use a 
   model (see the \emph{examples} section) that conditions on the specific male 
@@ -56,7 +56,7 @@
   \insertRef{mccullagh1989generalized}{lme4}
 }
 \examples{
-## Making sure Male, Female, and CRoss are treated as factors
+## Making sure Male, Female, and Cross are treated as factors
 salamander$Male <- factor(salamander$Male)
 salamander$Female <- factor(salamander$Female)
 salamander$Cross <- factor(salamander$Cross)


### PR DESCRIPTION
See: https://github.com/lme4/lme4/issues/552

I didn't mention `?simulate.merMod (newparams=)` since I didn't think it was actually that relevant.

Includes information regarding support for new covariance structures.

(Honestly prompting copilot was kind of exhausting and unnecessary here, I probably would've saved time writing this myself...)