### PR TITLE
Fix lme4::lmList prints grouping variable as NULL

### DIFF
--- a/R/lmList.R
+++ b/R/lmList.R
@@ -176,7 +176,8 @@ lmList <- function(formula, data, family, subset, weights,
         groups = ordered(groups),
         origOrder = match(unique(as.character(groups)), nms)
         )
-    attr(val, "groupsForm") <- reformulate(deparse(mform$groups))
+    # TODO: import reformulas::get_grpvars once reformulas has updated
+    attr(val, "groupsForm") <- reformulate(get_grpvars(formula))
     val
 }
 

--- a/R/lmList.R
+++ b/R/lmList.R
@@ -111,6 +111,11 @@ lmList <- function(formula, data, family, subset, weights,
     ## NA values in unused columns.  All we need the model frame for
     ## is evaluating the groups.
 
+    ff <- reformulas::findbars_x(formula)
+    if (length(ff) > 1) 
+      stop("lme4::lmList only works with simple grouping formulas (not involving * or /); 
+           use interaction(...) to construct an appropriate grouping variable first.")
+    
     ## keep weights and offsets in case we have NAs there??
     m <- match(c("formula", "data", "subset", "na.action",
                  "weights", "offset"), names(mf), 0)
@@ -171,9 +176,7 @@ lmList <- function(formula, data, family, subset, weights,
         groups = ordered(groups),
         origOrder = match(unique(as.character(groups)), nms)
         )
-    gf <- as.formula(paste("~", deparse(mform$groups)))
-    environment(gf) <- globalenv()
-    attr(val, "groupsForm") <- gf
+    attr(val, "groupsForm") <- reformulate(deparse(mform$groups))
     val
 }
 

--- a/R/lmList.R
+++ b/R/lmList.R
@@ -111,10 +111,11 @@ lmList <- function(formula, data, family, subset, weights,
     ## NA values in unused columns.  All we need the model frame for
     ## is evaluating the groups.
 
-    ff <- reformulas::findbars_x(formula)
+    # TODO: import reformulas::get_grpvars once reformulas has updated
+    ff <- get_grpvars(formula)
     if (length(ff) > 1) 
       stop("lme4::lmList only works with simple grouping formulas (not involving * or /); 
-           use interaction(...) to construct an appropriate grouping variable first.")
+            use interaction(...) to construct an appropriate grouping variable first.")
     
     ## keep weights and offsets in case we have NAs there??
     m <- match(c("formula", "data", "subset", "na.action",
@@ -176,8 +177,7 @@ lmList <- function(formula, data, family, subset, weights,
         groups = ordered(groups),
         origOrder = match(unique(as.character(groups)), nms)
         )
-    # TODO: import reformulas::get_grpvars once reformulas has updated
-    attr(val, "groupsForm") <- reformulate(get_grpvars(formula))
+    attr(val, "groupsForm") <- reformulate(ff)
     val
 }
 

--- a/R/lmList.R
+++ b/R/lmList.R
@@ -98,7 +98,8 @@ lmList <- function(formula, data, family, subset, weights,
     ## model.frame(groupedData) was problematic ... but not as we
     ## are currently using it.
 
-    mCall <- mf <- match.call()
+    mCall <- match.call()
+    mf <- mCall
     ## MM: I had this (instead of below  (inherited from nlme?)):
     ## if(!missing(subset))
     ##     data <- data[eval(asOneSidedFormula(mf[["subset"]])[[2]], data),, drop = FALSE]
@@ -459,4 +460,3 @@ for(fn in c("fitted", "fixef", "logLik", "pairs", "plot", "predict",
     assign(paste(fn, "lmList4", sep="."), meth)
 }
 rm(fn)
-

--- a/R/lmList.R
+++ b/R/lmList.R
@@ -98,8 +98,7 @@ lmList <- function(formula, data, family, subset, weights,
     ## model.frame(groupedData) was problematic ... but not as we
     ## are currently using it.
 
-    mCall <- match.call()
-    mf <- mCall
+    mCall <- mf <- match.call()
     ## MM: I had this (instead of below  (inherited from nlme?)):
     ## if(!missing(subset))
     ##     data <- data[eval(asOneSidedFormula(mf[["subset"]])[[2]], data),, drop = FALSE]
@@ -166,11 +165,16 @@ lmList <- function(formula, data, family, subset, weights,
         } else
             warning(wMsg, domain=NA)
     }
-    new("lmList4", setNames(val, nms),
+    val <- new("lmList4", 
+        setNames(val, nms),
         call = mCall, pool = pool,
         groups = ordered(groups),
         origOrder = match(unique(as.character(groups)), nms)
         )
+    gf <- as.formula(paste("~", deparse(mform$groups)))
+    environment(gf) <- globalenv()
+    attr(val, "groupsForm") <- gf
+    val
 }
 
 ## (currently hidden) auxiliaries

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1139,3 +1139,20 @@ getDoublevertDefault <- function() {
 na.action.merMod <- function(object, ...) {
   na.action(model.frame(object))
 }
+
+# Temporarily putting this here; should be removed once reformulas is updated.
+#' get grouping variable symbols/names
+#' @param formula a formula
+#' @param return_val return character string or raw symbol?
+#' @examples
+#' form <- Reaction ~ Days + (Days | group / Subject)
+#' get_grpvars(form)
+#' get_grpvars(form, return_val = "symbol")
+get_grpvars <- function(formula, return_val = c("char", "symbol")) {
+  return_val <- match.arg(return_val)
+  ff <- reformulas::findbars_x(formula)
+  ff2 <- lapply(ff, "[[", 2) ## strip parens/special names
+  ff3 <- lapply(ff2, "[[", 3) ## get argument after |
+  if (return_val == "symbol") return(ff3)
+  vapply(ff3, deparse1, FUN.VALUE = "")
+}

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -18,6 +18,8 @@
       covariances of different types (\code{mkReTrms} sorts random effects
       in decreasing order of number of grouping variable levels, this
       ordering was not applied consistently) (GH #945, Henrik Singmann)
+      \item fixed the case where \code{lme4::lmList} prints grouping variable 
+      as \code{NULL} (see GH #958)
     } % itemize
   } % bug fixes
   \subsection{NEW FEATURES}{

--- a/man/lmList.Rd
+++ b/man/lmList.Rd
@@ -75,6 +75,10 @@ lmList(formula, data, family, subset, weights, na.action,
 
     In previous \pkg{lme4} versions, a general (different) warning had
     been signalled in this case.
+    
+    \item To construct for cases in which there are nested grouping terms,
+    use \code{interaction()} to create a new grouping variable first. See the
+    example section.
   }
 }
 \examples{
@@ -86,6 +90,14 @@ stopifnot( all.equal(coef(fm.2), coef(fm.plm)) )
 
 (ci <- confint(fm.plm)) # print and rather *see* :
 plot(ci)                # how widely they vary for the individuals
+
+# Version with nested grouping below
+data(Pixel, package="nlme")
+# use interaction to deal with multi-level splitting
+Pixel$side_dog <- interaction(Pixel$Side, Pixel$Dog) 
+#side_dog is a substitution for Side/Dog
+form.pixel <- pixel ~ day + I(day^2) | side_dog
+(lmList(form.pixel, data = Pixel))
 }
 \seealso{\code{\linkS4class{lmList4}}}
 \keyword{models}

--- a/tests/testthat/test-lmList.R
+++ b/tests/testthat/test-lmList.R
@@ -210,3 +210,30 @@ if (requireNamespace("tibble")) {
     options(op)
   })
 }
+
+test_that("Ensure name of grouping variable matches", {
+  lme4_lmList <- lme4::lmList(Reaction ~ Days | Subject, sleepstudy)
+  nlme_lmList <- nlme::lmList(Reaction ~ Days | Subject, sleepstudy)
+  
+  lme4_sum <- summary(lme4_lmList)
+  nlme_sum <- summary(nlme_lmList)
+  
+  expect_equal( 
+    attr(lme4_sum, "groupsForm"), ~Subject, ignore_formula_env = TRUE
+  )
+  expect_equal(
+    attr(lme4_sum, "groupsForm"), attr(nlme_sum, "groupsForm"), 
+    ignore_formula_env = TRUE
+  )
+  
+})
+
+test_that("Warning provided if user adds various grouping terms", {
+  data(Pixel, package="nlme")
+  expect_error(
+    lme4::lmList(pixel ~ day + I(day^2) | Side/Dog, data = Pixel)
+  )
+  expect_error(
+    lme4::lmList(pixel ~ day + I(day^2) + (1| Side) + (1|Dog), data = Pixel)
+  )
+})

--- a/tests/testthat/test-lmList.R
+++ b/tests/testthat/test-lmList.R
@@ -35,6 +35,14 @@ test_that("basic lmList", {
 
 })
 
+test_that("lmList call preserves grouping variable in summary", {
+    fm <- lmList(Reaction ~ Days | Subject, sleepstudy)
+    sm <- summary(fm)
+    call_txt <- paste(deparse(sm$call), collapse = " ")
+    expect_match(call_txt, "\\| Subject")
+    expect_false(grepl("\\| NULL", call_txt))
+})
+
 test_that("orthodont", {
     data(Orthodont, package="nlme")
     fm2 <- lmList(distance ~ age | Subject, Orthodont)

--- a/tests/testthat/test-lmList.R
+++ b/tests/testthat/test-lmList.R
@@ -36,11 +36,9 @@ test_that("basic lmList", {
 })
 
 test_that("lmList call preserves grouping variable in summary", {
-    fm <- lmList(Reaction ~ Days | Subject, sleepstudy)
-    sm <- summary(fm)
-    call_txt <- paste(deparse(sm$call), collapse = " ")
-    expect_match(call_txt, "\\| Subject")
-    expect_false(grepl("\\| NULL", call_txt))
+  fm1_lmList <- lme4::lmList(Reaction ~ Days | Subject, sleepstudy)
+  expect_equal(typeof(attr(fm1_lmList, "groupsForm")), "language")
+  expect_equal(attr(fm1_lmList, "groupsForm"), as.formula("~Subject"))
 })
 
 test_that("orthodont", {


### PR DESCRIPTION
Every time you use lme4::lmList, for some reason, the print shows that the grouping variable is always NULL. See quick example below:
```
library(lme4)
test <- lme4::lmList(Reaction ~ Days | Subject, sleepstudy)
try(summary(test))
##Call:
##  Model: Reaction ~ Days | NULL 
##   Data: sleepstudy 
```
Note that this does not happen with nlme, which is where the function was copied from:
```
library(nlme)
data(sleepstudy, package="lme4")
test2 <- nlme::lmList(Reaction ~ Days | Subject, sleepstudy)
try(summary(test2))
##Call:
## Model: Reaction ~ Days | Subject 
##  Data: sleepstudy 
```

I found this problem when I was trying to investigate https://github.com/lme4/lme4/issues/377.

---

Now this issue is fixed. The problem was `print.summary.lmList`, which was borrowed from `nlme`, uses `attr(object, "groupsForm")` to pick the name for the `group` part of the `Model:` aspect in `print.summary`. This attribute did get generated before for `lme4::lmList`.

At first I tried to use copilot, but as I quickly had an idea of the issue when I debugged `print.summary.lmList`...
