### PR TITLE
Getting rid of the controversial assigning parent.frame() for weights and offsets in [g]lformula

### DIFF
--- a/R/modular.R
+++ b/R/modular.R
@@ -762,13 +762,7 @@ glFormula <- function(formula, data=NULL, family = gaussian,
                             keep_args = c(2L, 2L))
     environment(fr.form.) <- environment(fr.form) <-
         environment(formula)
-    ## model.frame.default looks for these objects in the environment
-    ## of the *formula* (see 'extras', which is anything passed in '...'),
-    ## so they have to be put there:
-    for (i in c("weights", "offset")) {
-        if (!eval(bquote(missing(x=.(i)))))
-            assign(i, get(i, parent.frame()), environment(fr.form))
-    }
+
     mf$formula <- fr.form
     fr <- eval(mf, parent.frame())
     ## convert character vectors to factor (defensive)

--- a/R/modular.R
+++ b/R/modular.R
@@ -375,13 +375,6 @@ lFormula <- function(formula, data=NULL, REML = TRUE,
                             keep_args = c(2L, 2L))
     environment(fr.form.) <- environment(fr.form) <-
         environment(formula)
-    ## model.frame.default looks for these objects in the environment
-    ## of the *formula* (see 'extras', which is anything passed in '...'),
-    ## so they have to be put there:
-    for (i in c("weights", "offset")) {
-        if (!eval(bquote(missing(x=.(i)))))
-            assign(i,get(i,parent.frame()),environment(fr.form))
-    }
     mf$formula <- fr.form
     fr <- eval(mf, parent.frame())
     if (nrow(fr) == 0L) stop("0 (non-NA) cases")

--- a/R/predict.R
+++ b/R/predict.R
@@ -703,13 +703,21 @@ simulate.merMod <- function(object, nsim = 1, seed = NULL, use.u = FALSE,
              sQuote("newparams"))
     }
 
+    ## watch out for https://github.com/lme4/lme4/issues/481
+    ## don't modify 'weights' in formula environment permanently
     nullWts <- FALSE
+    oldweights <- get("weights", environment(formula))
+    on.exit(assign("weights", oldweights, environment(formula)))
+            
     if (is.null(weights)) {
         if (is.null(newdata)) {
-            weights <- weights(object)
+            assign("weights", weights(object),
+                   environment(formula))
         } else {
             nullWts <- TRUE # this flags that 'weights' wasn't supplied by the user
-            weights <- rep(1,nrow(newdata))
+            assign("weights",
+                   rep(1,nrow(newdata)),
+                   environment(formula))
         }
     }
 

--- a/R/predict.R
+++ b/R/predict.R
@@ -706,9 +706,25 @@ simulate.merMod <- function(object, nsim = 1, seed = NULL, use.u = FALSE,
     ## watch out for https://github.com/lme4/lme4/issues/481
     ## don't modify 'weights' in formula environment permanently
     nullWts <- FALSE
-    oldweights <- get("weights", environment(formula))
-    on.exit(assign("weights", oldweights, environment(formula)))
-            
+    ## below is the previous code; unfortunately it fails a test
+    ## 'ensuring weights and offsets don't leak into global environment'
+    ## added in testthat/test-simulate_formula.R
+    #oldweights <- get("weights", environment(formula))
+    #on.exit(assign("weights", oldweights, environment(formula)))
+    oldweights <- if (exists("weights", environment(formula), inherits = FALSE)) {
+      get("weights", environment(formula), inherits = FALSE)
+    } else {
+      NULL
+    }
+    on.exit(
+      if (is.null(oldweights)) {
+        rm("weights", envir = environment(formula))
+      } else {
+        assign("weights", oldweights, environment(formula))
+      },
+      add = TRUE
+    )
+           
     if (is.null(weights)) {
         if (is.null(newdata)) {
             assign("weights", weights(object), environment(formula))
@@ -722,8 +738,19 @@ simulate.merMod <- function(object, nsim = 1, seed = NULL, use.u = FALSE,
     }
     
     ## using a similar trick for offsets 
-    oldoffset <- get("offset", environment(formula))
-    on.exit(assign("offset", oldoffset, environment(formula)))
+    oldoffset <- if (exists("offset", environment(formula), inherits = FALSE)) {
+      get("offset", environment(formula), inherits = FALSE)
+    } else {
+      NULL
+    }
+    on.exit(
+      if (is.null(oldoffset)) {
+        rm("offset", envir = environment(formula))
+      } else {
+        assign("offset", oldoffset, environment(formula))
+      },
+      add = TRUE
+    )
     
     if (is.null(offset)) {
       if (is.null(newdata)) {

--- a/R/predict.R
+++ b/R/predict.R
@@ -706,42 +706,46 @@ simulate.merMod <- function(object, nsim = 1, seed = NULL, use.u = FALSE,
     ## watch out for https://github.com/lme4/lme4/issues/481
     ## don't modify 'weights' in formula environment permanently
     nullWts <- FALSE
-    ## below is needed to ensure weights and offsets don't leak into 
-    ## the global environment
-    old <- list()
-    for (var in c("weights", "offset")) {
-      old[[var]] <- if (exists(var, environment(formula), inherits = FALSE)) {
-        get(var, environment(formula), inherits = FALSE)
-      } else {
-        list(NULL)  ## note https://cran.r-project.org/doc/FAQ/R-FAQ.html#How-can-I-set-components-of-a-list-to-NULL_003f
+    ## below is needed to ensure weights and offsets don't leak into
+    ## the formula environment (only when formula is non-NULL, i.e. the
+    ## simulate.formula path; when formula is NULL, e.g. simulate.merMod,
+    ## weights/offset are already available as local variables)
+    if (!is.null(formula)) {
+      old <- list()
+      for (var in c("weights", "offset")) {
+        old[[var]] <- if (exists(var, environment(formula), inherits = FALSE)) {
+          get(var, environment(formula), inherits = FALSE)
+        } else {
+          list(NULL)  ## note https://cran.r-project.org/doc/FAQ/R-FAQ.html#How-can-I-set-components-of-a-list-to-NULL_003f
+        }
       }
+      on.exit(
+        lapply(names(old),
+               function(name) {
+                 value <- old[[name]]
+                 ## if we have that weights/offsets did not exist,
+                 ## need to add an extra [[1]] to value to access the NULL value
+                 if (is.null(value[[1]])) {
+                   rm(list = name, envir = environment(formula))
+                 } else {
+                   assign(name, value, envir = environment(formula))
+                 }
+               }),
+        add = TRUE
+      )
+
+      assign("weights",
+             if (!is.null(weights)) weights
+             else if (is.null(newdata)) weights(object)
+             else { nullWts <- TRUE; rep(1, nrow(newdata)) },
+             environment(formula))
+
+      assign("offset",
+             if (!is.null(offset)) offset
+             else if (is.null(newdata)) offset(object)
+             else rep(0, nrow(newdata)),
+             environment(formula))
     }
-    on.exit(
-      lapply(names(old),
-             function(name) {
-               value <- old[[name]]
-               ## if we have that weights/offsets did not exist,
-               ## need to add an extra [[1]] to value to access the NULL value
-               if (is.null(value[[1]])) {
-                 rm(list = name, envir = environment(formula))
-               } else {
-                 assign(name, value, envir = environment(formula))
-               }
-             }),
-      add = TRUE
-    )
-    
-    assign("weights",
-           if (!is.null(weights)) weights
-           else if (is.null(newdata)) weights(object)
-           else { nullWts <- TRUE; rep(1, nrow(newdata)) },
-           environment(formula))
-    
-    assign("offset",
-           if (!is.null(offset)) offset
-           else if (is.null(newdata)) offset(object)
-           else rep(0, nrow(newdata)),
-           environment(formula))
 
     if (missing(object)) {
 

--- a/R/predict.R
+++ b/R/predict.R
@@ -706,61 +706,42 @@ simulate.merMod <- function(object, nsim = 1, seed = NULL, use.u = FALSE,
     ## watch out for https://github.com/lme4/lme4/issues/481
     ## don't modify 'weights' in formula environment permanently
     nullWts <- FALSE
-    ## below is the previous code; unfortunately it fails a test
-    ## 'ensuring weights and offsets don't leak into global environment'
-    ## added in testthat/test-simulate_formula.R
-    #oldweights <- get("weights", environment(formula))
-    #on.exit(assign("weights", oldweights, environment(formula)))
-    oldweights <- if (exists("weights", environment(formula), inherits = FALSE)) {
-      get("weights", environment(formula), inherits = FALSE)
-    } else {
-      NULL
-    }
-    on.exit(
-      if (is.null(oldweights)) {
-        rm("weights", envir = environment(formula))
+    ## below is needed to ensure weights and offsets don't leak into 
+    ## the global environment
+    old <- list()
+    for (var in c("weights", "offset")) {
+      old[[var]] <- if (exists(var, environment(formula), inherits = FALSE)) {
+        get(var, environment(formula), inherits = FALSE)
       } else {
-        assign("weights", oldweights, environment(formula))
-      },
-      add = TRUE
-    )
-           
-    if (is.null(weights)) {
-        if (is.null(newdata)) {
-            assign("weights", weights(object), environment(formula))
-        } else {
-            nullWts <- TRUE # this flags that 'weights' wasn't supplied by the user
-            assign("weights", rep(1,nrow(newdata)), environment(formula))
-        }
-    } else {
-      ## need to add another constraint (helps with the test involving tmpf2)
-      assign("weights", weights, environment(formula))
-    }
-    
-    ## using a similar trick for offsets 
-    oldoffset <- if (exists("offset", environment(formula), inherits = FALSE)) {
-      get("offset", environment(formula), inherits = FALSE)
-    } else {
-      NULL
-    }
-    on.exit(
-      if (is.null(oldoffset)) {
-        rm("offset", envir = environment(formula))
-      } else {
-        assign("offset", oldoffset, environment(formula))
-      },
-      add = TRUE
-    )
-    
-    if (is.null(offset)) {
-      if (is.null(newdata)) {
-        assign("offset", offset(object), environment(formula))
-      } else {
-        assign("offset", rep(0,nrow(newdata)), environment(formula))
+        list(NULL)  ## note https://cran.r-project.org/doc/FAQ/R-FAQ.html#How-can-I-set-components-of-a-list-to-NULL_003f
       }
-    } else {
-      assign("offset", offset, environment(formula))
     }
+    on.exit(
+      lapply(names(old),
+             function(name) {
+               value <- old[[name]]
+               ## if we have that weights/offsets did not exist,
+               ## need to add an extra [[1]] to value to access the NULL value
+               if (is.null(value[[1]])) {
+                 rm(list = name, envir = environment(formula))
+               } else {
+                 assign(name, value, envir = environment(formula))
+               }
+             }),
+      add = TRUE
+    )
+    
+    assign("weights",
+           if (!is.null(weights)) weights
+           else if (is.null(newdata)) weights(object)
+           else { nullWts <- TRUE; rep(1, nrow(newdata)) },
+           environment(formula))
+    
+    assign("offset",
+           if (!is.null(offset)) offset
+           else if (is.null(newdata)) offset(object)
+           else rep(0, nrow(newdata)),
+           environment(formula))
 
     if (missing(object)) {
 

--- a/R/predict.R
+++ b/R/predict.R
@@ -711,14 +711,28 @@ simulate.merMod <- function(object, nsim = 1, seed = NULL, use.u = FALSE,
             
     if (is.null(weights)) {
         if (is.null(newdata)) {
-            assign("weights", weights(object),
-                   environment(formula))
+            assign("weights", weights(object), environment(formula))
         } else {
             nullWts <- TRUE # this flags that 'weights' wasn't supplied by the user
-            assign("weights",
-                   rep(1,nrow(newdata)),
-                   environment(formula))
+            assign("weights", rep(1,nrow(newdata)), environment(formula))
         }
+    } else {
+      ## need to add another constraint (helps with the test involving tmpf2)
+      assign("weights", weights, environment(formula))
+    }
+    
+    ## using a similar trick for offsets 
+    oldoffset <- get("offset", environment(formula))
+    on.exit(assign("offset", oldoffset, environment(formula)))
+    
+    if (is.null(offset)) {
+      if (is.null(newdata)) {
+        assign("offset", offset(object), environment(formula))
+      } else {
+        assign("offset", rep(0,nrow(newdata)), environment(formula))
+      }
+    } else {
+      assign("offset", offset, environment(formula))
     }
 
     if (missing(object)) {
@@ -861,6 +875,10 @@ simulate.merMod <- function(object, nsim = 1, seed = NULL, use.u = FALSE,
             if(nullWts) weights <- rowSums(r)
         }
 
+        ## fallback -- need weights to not be null. this is to ensure that the 
+        ## lme4 simulate example doesn't fail.
+        if (is.null(weights)) weights <- rep(1, n)
+        
         if (is.null(sfun <- simfunList[[family$family]])) {
             ## family$simulate just won't work ...
             ## sim funs must be hard-coded, see below

--- a/misc/env_tests.R
+++ b/misc/env_tests.R
@@ -1,0 +1,92 @@
+## see https://github.com/lme4/lme4/pull/811
+## https://github.com/lme4/lme4/pull/954
+##  (which raised the initial question of whether we could
+##   move the assign() stuff from lFormula/glFormula into their
+##   refactored/modular core, and whether we would need an additional
+##   level of parent.frame)
+## https://github.com/lme4/lme4/issues/481 (overwriting weights/offsets in global frame)
+
+library(lme4)
+library(testthat)
+
+## example 1 from krlmr
+my_weights <- rep(1, 6L)
+formula <- mpg ~ disp + (1 | cyl)
+
+lf1 <- local({
+  my_weights = rep(2, 6L)
+  lme4::lFormula(formula, data = head(mtcars), weights = my_weights)$fr[["(weights)"]]
+})
+print(lf1) ## matches global, not local (confusing, but defensible, as
+           ##  it's looking in the environment of the formula)
+
+rm(my_weights) ## clean up
+rm(formula)
+
+## example 2 from krlmr
+formula = mpg ~ disp + (1 | cyl)
+
+local({
+  tbl = head(mtcars)
+  try(lme4::lFormula(formula, data = tbl, weights = tbl$hp)$fr)
+})
+
+## fails (object 'tbl' not found)
+
+## this works:
+local({
+  tbl = head(mtcars)
+  lme4::lFormula(formula, data = tbl, weights = hp)$fr[["(weights)"]]
+})
+
+
+## with lFormula(...) this breaks model.frame already
+## match.call is
+##   lFormula(formula = ..1, data = ..2, weights = ..3)
+## mf has turned into
+##  stats::model.frame(data = ..2, weights = ..3, drop.unused.levels = TRUE, 
+##         formula = mpg ~ disp + (1 + cyl))
+
+get_comp <- function(..., w = c("(weights)", "(offset)")) {
+    w <- match.arg(w)
+    lf <- do.call(lFormula, list(...))
+    ## lf <- lFormula(...)
+    lf$fr[[w]]
+    
+}
+
+lf1 <- local({
+  my_weights = rep(2, 6L)
+  get_comp(formula, data = head(mtcars), weights = my_weights)
+})
+
+lf1
+
+## try some simulation tests
+##  * new code doesn't break simulations
+##  * we don't create new 'weights' vars in the formula environment,
+##   or overwrite existing ones
+
+cbpp$obs <- factor(seq(nrow(cbpp)))
+fit_cbpp_0 <- glmer(cbind(incidence, size-incidence) ~ 1 + (1|herd),
+                    cbpp, family=binomial)
+## include fixed effect of period
+fit_cbpp_1 <- update(fit_cbpp_0, . ~ . + period)
+## include observation-level RE
+fit_cbpp_2 <- update(fit_cbpp_1, . ~ . + (1|obs))
+
+environment(formula(fit_cbpp_2))  ## global
+
+chk_wts_absent <- function() {
+    testthat::expect_identical(find("weights"), c(".GlobalEnv", "package:stats"))
+}
+weights <- wts_orig <- c(NA_real_, NA_real_)
+
+expect_is(simulate(fit_cbpp_2), "data.frame")
+p1 <- simulate(fit_cbpp_2, re.form = NULL, seed = 101)
+sim <- simulate(formula(fit_cbpp_2), newdata = cbpp,
+         family = binomial,
+         newparams = list(theta = c(1,1),
+                          beta = rep(0,4)))
+chk_wts_absent()
+expect_identical(weights, wts_orig)

--- a/tests/testthat/test-simulate_formula.R
+++ b/tests/testthat/test-simulate_formula.R
@@ -82,8 +82,7 @@ test_that("ensuring weights and offsets don't leak into global environment", {
   expect_false(exists("offset", envir = environment(form), 
                       inherits = FALSE))
   # weights and offsets have been assigned
-  weights <- offset <- 1:10  
-  offset <- 1:10
+  weights <- offset <- 1:10
   d1$y2 <- simulate(form, family=binomial, weights=d1$w, newdata=d1,
                    newparams=list(theta=0.01, beta=c(1,1)))[[1]]
   expect_equal(weights, 1:10)

--- a/tests/testthat/test-simulate_formula.R
+++ b/tests/testthat/test-simulate_formula.R
@@ -88,3 +88,65 @@ test_that("ensuring weights and offsets don't leak into global environment", {
   expect_equal(weights, 1:10)
   expect_equal(offset, 1:10)
 })
+
+## Test simulate.merMod path (formula=NULL), verifying:
+## (1) it works without error
+## (2) weights/offset in the calling environment are not contaminated
+## See https://github.com/lme4/lme4/pull/961
+
+test_that("simulate.merMod works and does not contaminate calling environment", {
+  ## basic LMM
+  fm1 <- lmer(Reaction ~ Days + (Days | Subject), sleepstudy)
+  ## plain simulate.merMod (formula=NULL path)
+  set.seed(1)
+  s1 <- simulate(fm1, nsim=2, seed=1)
+  expect_equal(nrow(s1), nrow(sleepstudy))
+  expect_equal(ncol(s1), 2L)
+
+  ## verify that weights/offset in the calling env are not overwritten
+  weights <- 99L
+  offset  <- 88L
+  s2 <- simulate(fm1, nsim=1, seed=1)
+  expect_equal(weights, 99L)
+  expect_equal(offset,  88L)
+
+  ## simulate.merMod with newdata
+  set.seed(42)
+  s3 <- simulate(fm1, nsim=1, seed=42, newdata=sleepstudy)
+  expect_equal(nrow(s3), nrow(sleepstudy))
+})
+
+test_that("simulate.merMod with weights does not contaminate calling environment", {
+  ## GLMM with weights
+  gm1 <- suppressMessages(
+    glmer(cbind(incidence, size - incidence) ~ period + (1 | herd),
+          data = cbpp, family = binomial)
+  )
+
+  ## plain simulate (no extra weights argument) - should use model weights
+  weights <- 42L
+  offset  <- 7L
+  s1 <- simulate(gm1, nsim=1, seed=1)
+  expect_equal(nrow(s1), nrow(cbpp))
+  ## calling-environment vars must be untouched
+  expect_equal(weights, 42L)
+  expect_equal(offset,  7L)
+})
+
+test_that("simulate via formula with explicit weights/offset values work correctly", {
+  ## simulate via formula path with weights and offsets
+  form <- ~x + (1|f)
+  d1 <- data.frame(x=rnorm(60), f=factor(rep(1:6,each=10)), w=rep(10,60))
+  off_val <- rep(0.1, 60)
+
+  set.seed(1)
+  s_wts <- simulate(form, family=binomial, weights=d1$w, newdata=d1,
+                    newparams=list(theta=0.01, beta=c(1,1)), seed=1)[[1]]
+  expect_equal(length(s_wts), nrow(d1))
+
+  set.seed(1)
+  s_off <- simulate(form, family=binomial, weights=d1$w, offset=off_val,
+                    newdata=d1,
+                    newparams=list(theta=0.01, beta=c(1,1)), seed=1)[[1]]
+  expect_equal(length(s_off), nrow(d1))
+})

--- a/tests/testthat/test-simulate_formula.R
+++ b/tests/testthat/test-simulate_formula.R
@@ -65,3 +65,27 @@ test_that("two-sided formula warning", {
 ## rmx("simulate.formula_lhs_numeric")
 
 suppressWarnings(try(rm(list = c("simulate.formula_lhs_", "simulate.formula_lhs_numeric")),silent=TRUE))
+
+## in general, we shouldn't have it such that weights and offsets leak into the
+## global environment.
+
+test_that("ensuring weights and offsets don't leak into global environment", {
+  # weights have not yet been assigned
+  form <- ~x + (1|f)
+  # First simulate - with weights of 10
+  d1 <- data.frame(x=rnorm(60), f=factor(rep(1:6,each=10)), w=rep(10,60))
+  d1$y1 <- simulate(form, family=binomial, weights=d1$w, newdata=d1,
+                   newparams=list(theta=0.01, beta=c(1,1)))[[1]]
+  # ensures it was not leaked in the local environment!
+  expect_false(exists("weights", envir = environment(form), 
+                      inherits = FALSE))
+  expect_false(exists("offset", envir = environment(form), 
+                      inherits = FALSE))
+  # weights and offsets have been assigned
+  weights <- offset <- 1:10  
+  offset <- 1:10
+  d1$y2 <- simulate(form, family=binomial, weights=d1$w, newdata=d1,
+                   newparams=list(theta=0.01, beta=c(1,1)))[[1]]
+  expect_equal(weights, 1:10)
+  expect_equal(offset, 1:10)
+})

--- a/tests/testthat/test-simulate_formula.R
+++ b/tests/testthat/test-simulate_formula.R
@@ -69,84 +69,102 @@ suppressWarnings(try(rm(list = c("simulate.formula_lhs_", "simulate.formula_lhs_
 ## in general, we shouldn't have it such that weights and offsets leak into the
 ## global environment.
 
-test_that("ensuring weights and offsets don't leak into global environment", {
-  # weights have not yet been assigned
-  form <- ~x + (1|f)
-  # First simulate - with weights of 10
-  d1 <- data.frame(x=rnorm(60), f=factor(rep(1:6,each=10)), w=rep(10,60))
-  d1$y1 <- simulate(form, family=binomial, weights=d1$w, newdata=d1,
-                   newparams=list(theta=0.01, beta=c(1,1)))[[1]]
-  # ensures it was not leaked in the local environment!
-  expect_false(exists("weights", envir = environment(form), 
-                      inherits = FALSE))
-  expect_false(exists("offset", envir = environment(form), 
-                      inherits = FALSE))
-  # weights and offsets have been assigned
-  weights <- offset <- 1:10
-  d1$y2 <- simulate(form, family=binomial, weights=d1$w, newdata=d1,
-                   newparams=list(theta=0.01, beta=c(1,1)))[[1]]
-  expect_equal(weights, 1:10)
-  expect_equal(offset, 1:10)
-})
-
-## Test simulate.merMod path (formula=NULL), verifying:
-## (1) it works without error
-## (2) weights/offset in the calling environment are not contaminated
+### fixing weights and offsets in simulateFun
 ## See https://github.com/lme4/lme4/pull/961
-
-test_that("simulate.merMod works and does not contaminate calling environment", {
-  ## basic LMM
+test_that("weights and offset do not leak into or overwrite calling environment", {
+  
+  form <- ~x + (1|f)
+  d1 <- data.frame(x = rnorm(60), f = factor(rep(1:6, each = 10)), w = rep(10, 60))
+  
+  # before assignment: variables must not be created in form's environment
+  d1$y1 <- simulate(form, family = binomial, weights = d1$w, newdata = d1,
+                    newparams = list(theta = 0.01, beta = c(1, 1)))[[1]]
+  expect_false(exists("weights", envir = environment(form), inherits = FALSE))
+  expect_false(exists("offset",  envir = environment(form), inherits = FALSE))
+  
+  # after assignment: existing variables in calling env must not be overwritten
+  weights <- offset <- 1:10
+  d1$y2 <- simulate(form, family = binomial, weights = d1$w, newdata = d1,
+                    newparams = list(theta = 0.01, beta = c(1, 1)))[[1]]
+  expect_equal(weights, 1:10)
+  expect_equal(offset,  1:10)
+  
+  ## using merMod to simulate, where formula = NULL
   fm1 <- lmer(Reaction ~ Days + (Days | Subject), sleepstudy)
-  ## plain simulate.merMod (formula=NULL path)
-  set.seed(1)
-  s1 <- simulate(fm1, nsim=2, seed=1)
-  expect_equal(nrow(s1), nrow(sleepstudy))
-  expect_equal(ncol(s1), 2L)
-
-  ## verify that weights/offset in the calling env are not overwritten
-  weights <- 99L
-  offset  <- 88L
-  s2 <- simulate(fm1, nsim=1, seed=1)
-  expect_equal(weights, 99L)
-  expect_equal(offset,  88L)
-
-  ## simulate.merMod with newdata
-  set.seed(42)
-  s3 <- simulate(fm1, nsim=1, seed=42, newdata=sleepstudy)
-  expect_equal(nrow(s3), nrow(sleepstudy))
-})
-
-test_that("simulate.merMod with weights does not contaminate calling environment", {
-  ## GLMM with weights
+  
+  weights <- 1:34
+  offset  <- 34L
+  simulate(fm1, weights = sample(1:2, replace = TRUE, size = nrow(sleepstudy)))
+  expect_equal(weights, 1:34)
+  expect_equal(offset,  34L)
+  
+  # also works for glmer
   gm1 <- suppressMessages(
     glmer(cbind(incidence, size - incidence) ~ period + (1 | herd),
           data = cbpp, family = binomial)
   )
-
-  ## plain simulate (no extra weights argument) - should use model weights
+  simulate(gm1, weights = sample(1:2, replace = TRUE, size = nrow(cbpp)), offset = 1)
+  expect_equal(weights, 1:34)
+  expect_equal(offset,  34L)
+  
+  # must not overwrite already-assigned vars either
+  weights <- 99L
+  offset  <- 88L
+  simulate(fm1, nsim = 1, seed = 1)
+  expect_equal(weights, 99L)
+  expect_equal(offset,  88L)
+  
+  # same for glmer with model weights
   weights <- 42L
-  offset  <- 7L
-  s1 <- simulate(gm1, nsim=1, seed=1)
-  expect_equal(nrow(s1), nrow(cbpp))
-  ## calling-environment vars must be untouched
+  offset  <-  7L
+  simulate(gm1, nsim = 1, seed = 1)
   expect_equal(weights, 42L)
-  expect_equal(offset,  7L)
+  expect_equal(offset,   7L)
 })
 
-test_that("simulate via formula with explicit weights/offset values work correctly", {
-  ## simulate via formula path with weights and offsets
+test_that("simulate.merMod returns correct dimensions and works with newdata", {
+  fm1 <- lmer(Reaction ~ Days + (Days | Subject), sleepstudy)
+  
+  s1 <- simulate(fm1, nsim = 2, seed = 1)
+  expect_equal(nrow(s1), nrow(sleepstudy))
+  expect_equal(ncol(s1), 2L)
+  
+  s2 <- simulate(fm1, nsim = 1, seed = 42, newdata = sleepstudy)
+  expect_equal(nrow(s2), nrow(sleepstudy))
+})
+
+## same seed, different weights/offset values must produce different results.
+
+test_that("weights and offset arguments are respected by simulate", {
+  fm1 <- lmer(Reaction ~ Days + (Days | Subject), sleepstudy)
+  
+  # different weights -> different output
+  set.seed(1)
+  s1 <- simulate(fm1, weights = sample(1:2, replace = TRUE, size = nrow(sleepstudy)))
+  s2 <- simulate(fm1, weights = sample(3:4, replace = TRUE, size = nrow(sleepstudy)))
+  expect_false(isTRUE(all.equal(s1[[1]], s2[[1]])))
+  
+  # different offsets -> different output
+  set.seed(2)
+  s3 <- simulate(fm1, offset = 1)
+  s4 <- simulate(fm1, offset = 2)
+  expect_false(isTRUE(all.equal(s3[[1]], s4[[1]])))
+})
+
+## simulate.formula correctly handles explicit weights and offset values.
+test_that("simulate via formula path accepts weights and offset without error", {
   form <- ~x + (1|f)
-  d1 <- data.frame(x=rnorm(60), f=factor(rep(1:6,each=10)), w=rep(10,60))
+  d1      <- data.frame(x = rnorm(60), f = factor(rep(1:6, each = 10)), w = rep(10, 60))
   off_val <- rep(0.1, 60)
-
-  set.seed(1)
-  s_wts <- simulate(form, family=binomial, weights=d1$w, newdata=d1,
-                    newparams=list(theta=0.01, beta=c(1,1)), seed=1)[[1]]
+  
+  s_wts <- simulate(form, family = binomial, weights = d1$w,
+                    newdata = d1, newparams = list(theta = 0.01, beta = c(1, 1)),
+                    seed = 1)[[1]]
   expect_equal(length(s_wts), nrow(d1))
-
-  set.seed(1)
-  s_off <- simulate(form, family=binomial, weights=d1$w, offset=off_val,
-                    newdata=d1,
-                    newparams=list(theta=0.01, beta=c(1,1)), seed=1)[[1]]
+  
+  s_off <- simulate(form, family = binomial, weights = d1$w, offset = off_val,
+                    newdata = d1, newparams = list(theta = 0.01, beta = c(1, 1)),
+                    seed = 1)[[1]]
   expect_equal(length(s_off), nrow(d1))
 })
+


### PR DESCRIPTION
The lines I am referring to:
```
 for (i in c("weights", "offset")) { 
     if (!eval(bquote(missing(x=.(i))))) 
         assign(i,get(i,parent.frame()),environment(fr.form)) 
 } 
```
A previous pull request (https://github.com/lme4/lme4/pull/811) suggests that we should just get rid of `parent.frame()`. However, it turns out the main problem is regarding `.simulateFun` (see: https://github.com/lme4/lme4/pull/811#issuecomment-4112251606)

This pull request should also fix this issue as well: https://github.com/lme4/lme4/issues/481 

Few notes:
1. I added a function that should be in `reformulas` (`get_grpvars`) temporarily; we'll manually remove this on the latest release of `reformulas` (I'll probably remember.)
2. This does NOT fix this issue: https://github.com/lme4/lme4/pull/954; I'd need to edit the other pull request a bit more.
