### PR TITLE
Minor bug in tests occur when devdiff is NULL

### DIFF
--- a/R/profile.R
+++ b/R/profile.R
@@ -263,7 +263,7 @@ profile.merMod <- function(fitted,
                 if(devdiff < 0)
                     warning(gettextf("slightly lower deviances (diff=%g) detected",
                                      devdiff), domain=NA)
-                if (devdiff <= 0) devdiff <- devtol
+                if (is.na(devdiff) && devdiff <= 0) devdiff <- devtol
             }
             zz <- sign(xx - pw) * sqrt(devdiff)
             r <- c(zz, mkpar(npar1, w, xx, pars))


### PR DESCRIPTION
Sometimes `devdiff` is passed as `NA_real_` in which there is an error with the line `if(devdiff <= 0)`...